### PR TITLE
Fix: repo split

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -17,8 +17,6 @@
 #     a. REGISTRY_USERNAME with ACR username
 #     b. REGISTRY_PASSWORD with ACR Password
 #     c. AZURE_CREDENTIALS with the output of `az ad sp create-for-rbac --sdk-auth`
-#     d. DEV_REGISTRY_USERNAME with the DEV ACR username
-#     e. DEV_REGISTRY_PASSWORD with the DEV ACR Password
 #
 # 2. Change the values for the REGISTRY_NAME, CLUSTER_NAME, CLUSTER_RESOURCE_GROUP and NAMESPACE environment variables (below in build-push).
 name: build_and_push
@@ -57,7 +55,6 @@ jobs:
   build-push:
     env:
       REGISTRY_NAME: k8scc01covidacr
-      DEV_REGISTRY_NAME: k8scc01covidacrdev
       CLUSTER_NAME: k8s-cancentral-01-covid-aks
       CLUSTER_RESOURCE_GROUP: k8s-cancentral-01-covid-aks
       LOCAL_REPO: localhost:5000
@@ -119,13 +116,6 @@ jobs:
         login-server: ${{ env.REGISTRY_NAME }}.azurecr.io
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
-    
-    # Connect to Azure DEV Container registry (ACR)
-    - uses: azure/docker-login@v1
-      with:
-        login-server: ${{ env.DEV_REGISTRY_NAME }}.azurecr.io
-        username: ${{ secrets.DEV_REGISTRY_USERNAME }}
-        password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
     
     # Image building/storing locally
     - name: Make Dockerfiles

--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -25,7 +25,7 @@ name: build_and_push
 on:
   schedule:
     # Execute at 2am EST every day
-    - cron:  '0 21 * * *'
+    - cron:  '0 7 * * *'
   push:
     branches:
       - 'master-2.0'
@@ -238,4 +238,4 @@ jobs:
       uses: act10ns/slack@v1
       with: 
         status: failure
-        message: Build failed. https://github.com/StatCan/aaw-kubeflow-containers/actions/runs/${{github.run_id}}
+        message: Build failed. https://github.com/StatCan/zone-kubeflow-containers/actions/runs/${{github.run_id}}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Zone-kubelfow-containers
+
+This readme has not yet been updated from when this project was a part of [aaw-kubeflow-containers](https://github.com/StatCan/aaw-kubeflow-containers).
+Much of it is out of date and doesn't apply. 
+
 # Containers for Kubeflow
 
 Container images to be used with kubeflow on the AAW platform for Data Science & other workloads.

--- a/make_helpers/get_branch_name.sh
+++ b/make_helpers/get_branch_name.sh
@@ -11,9 +11,9 @@ if [[ $GITHUB_ACTIONS == "true" ]] ; then
 		BRANCH_NAME=${BASH_REMATCH[1]}
 	elif [[ $GITHUB_REF =~ $PR_PATTERN ]]; then
 		PR_NUMBER=${BASH_REMATCH[1]}
-		# If not specified, assume PR comes from StatCan/aaw-kubeflow-containers
+		# If not specified, assume PR comes from StatCan/zone-kubeflow-containers
 		OWNER=${OWNER:-StatCan}
-	    REPOSITORY=${REPOSITORY:-aaw-kubeflow-containers}
+	    REPOSITORY=${REPOSITORY:-zone-kubeflow-containers}
 	    BRANCH_NAME=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/$OWNER/$REPOSITORY/pulls/$PR_NUMBER | jq '.head.ref')
 	    # Remove leading/trailing quotes
 	    BRANCH_NAME=$(sed -e 's/^"//' -e 's/"$//' <<<"$BRANCH_NAME")


### PR DESCRIPTION
This fixes a couple things that would break with the new url
also updated the readme to note that it's out of date and for `aaw-kubeflow-containers` and not for the zone