### PR TITLE
fix: start-custom.sh

### DIFF
--- a/images/cmd/Dockerfile
+++ b/images/cmd/Dockerfile
@@ -8,6 +8,7 @@ COPY start-custom.sh start-oms.sh restart-oms.sh /usr/local/bin/
 COPY trino-wrapper.sh /usr/local/bin/trino
 
 RUN chmod +x /usr/local/bin/start-oms.sh && \
+    chmod +x /usr/local/bin/start-custom.sh && \
     chmod +x /usr/local/bin/restart-oms.sh
 
 # Add --user to all pip install calls and point pip to Artifactory repository


### PR DESCRIPTION
Containers not starting because `start-custom.sh` isn't permissioned as excecutable