### PR TITLE
Remove jupyter contrib nbextensions

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -55,7 +55,6 @@ COPY coder.json $CS_TEMP_HOME/
 
 RUN pip install \
     'git+https://github.com/betatim/vscode-binder' && \
-    # jupyter_contrib_nbextensions likes to be installed with pip
     mamba install --quiet --yes -c conda-forge \
     # https://stackoverflow.com/questions/68824450/error-configuration-failed-for-package-ragg
     # need to add mamba install pkg-config so R can find freetype related packages

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -77,7 +77,6 @@ RUN pip install \
     'jupyterlab-lsp' \
     'jupyter-lsp'  && \
     jupyter server extension enable --py jupyter_server_proxy && \
-    jupyter nbextension enable codefolding/main --sys-prefix && \
     jupyter labextension enable \
       '@jupyterlab/translation-extension' \
       '@jupyterlab/server-proxy' \
@@ -268,7 +267,8 @@ RUN PYTHON_VERSION=$(python3 -c "import sys; print(f'python{sys.version_info.maj
     && cp /tmp/sascfg.py /opt/conda/lib/$PYTHON_VERSION/site-packages/saspy/sascfg.py \
     && rm /tmp/sascfg.py
 
-RUN jupyter nbextension install --py sas_kernel.showSASLog && \
+RUN jupyter nbextension enable codefolding/main --sys-prefix && \
+    jupyter nbextension install --py sas_kernel.showSASLog && \
     jupyter nbextension enable sas_kernel.showSASLog --py && \
     jupyter nbextension install --py sas_kernel.theme && \
     jupyter nbextension enable sas_kernel.theme --py && \

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -61,7 +61,6 @@ RUN pip install \
     'nodejs' \
     'pkg-config' \
     'jupyterlab' \
-    'jupyter_contrib_nbextensions' \ 
     'dash' \
     'plotly' \
     'ipywidgets' \

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -266,13 +266,6 @@ RUN PYTHON_VERSION=$(python3 -c "import sys; print(f'python{sys.version_info.maj
     && cp /tmp/sascfg.py /opt/conda/lib/$PYTHON_VERSION/site-packages/saspy/sascfg.py \
     && rm /tmp/sascfg.py
 
-RUN jupyter nbextension enable codefolding/main --sys-prefix && \
-    jupyter nbextension install --py sas_kernel.showSASLog && \
-    jupyter nbextension enable sas_kernel.showSASLog --py && \
-    jupyter nbextension install --py sas_kernel.theme && \
-    jupyter nbextension enable sas_kernel.theme --py && \
-    jupyter nbextension list
-
 # Must be set in deepest image
 ENV DEFAULT_JUPYTER_URL=/lab 
 

--- a/images/mid/jupyterlab-overrides.json
+++ b/images/mid/jupyterlab-overrides.json
@@ -1,5 +1,8 @@
 {
     "@jupyterlab/notebook-extension:tracker" : {
         "recordTiming": true
+    },
+    "@jupyterlab/codemirror-extension:commands": {
+        "codeFolding": true
     }
 }

--- a/images/mid/jupyterlab-overrides.json
+++ b/images/mid/jupyterlab-overrides.json
@@ -1,8 +1,6 @@
 {
     "@jupyterlab/notebook-extension:tracker" : {
-        "recordTiming": true
-    },
-    "@jupyterlab/codemirror-extension:commands": {
+        "recordTiming": true,
         "codeFolding": true
     }
 }

--- a/images/mid/jupyterlab-overrides.json
+++ b/images/mid/jupyterlab-overrides.json
@@ -1,6 +1,10 @@
 {
     "@jupyterlab/notebook-extension:tracker" : {
         "recordTiming": true,
-        "codeFolding": true
+        "codeCellConfig": {
+            "codeFolding": true,
+            "lineNumbers": false,
+            "lineWrap": false
+        }
     }
 }


### PR DESCRIPTION
# Description

Removal of the `nbextensions` 
This extension only effects `Jupyter Notebooks` not `Jupyterlab`'s notebooks. 

Enables the built in code folding setting. 

See: https://github.com/StatCan/aaw/issues/2032
for the full break down of the investigation and changes. 

## Notes

The removal of the `nbextensions` changes the version dependencies, and so a higher version of `notebook` in installed
~~6.5.7~~ -> 7.3.2

An extra extension is listed in the left side bar
`jupyter-notebook-lab-extension`