### PR TITLE
feat(filer_path_normalizer): create filer path normalizer shell script

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update --yes \
 
 COPY suspend-server.sh /usr/local/bin
 COPY adjust-server-resources.py /usr/local/bin
+COPY normalize_filer_path.sh /usr/local/bin
+
 
 # https://github.com/StatCan/aaw-kubeflow-containers/issues/293
 RUN mamba install --quiet \
@@ -27,7 +29,8 @@ RUN mamba install --quiet \
       fix-permissions $CONDA_DIR && \
       fix-permissions /home/$NB_USER && \
       chmod +x /usr/local/bin/suspend-server.sh && \
-      chmod +x /usr/local/bin/adjust-server-resources.py
+      chmod +x /usr/local/bin/adjust-server-resources.py && \
+      chmod +x /usr/local/bin/normalize_filer_path.sh
 
 # Add helpers for shell initialization
 COPY shell_helpers.sh /tmp/shell_helpers.sh

--- a/images/normalize_filer_path.sh
+++ b/images/normalize_filer_path.sh
@@ -1,0 +1,41 @@
+#! /bin/env bash
+#
+# File: normalize_filer_path.sh
+#
+# Author: Marcello Barisonzi <marcello.barisonzi@statcan.gc.ca>
+#
+# Purpose: Convert UNC path to Zone path
+#
+# Usage: 
+# 1. edit the FILER_ROOT variable to the UNC root of your filer (e.g. \\<SERVER_NAME>\<BASE_FOLDER>)
+# 2. edit the LOCAL_FILER_PATH to the filer folder on the Zone (e.g. `"/home/jovyan/filers/fldXfilersvm"`)
+# 3. source this file: . normalize_filer_path.sh
+# 4. run the command: nfp "<UNC_path>" (please remember the double quotes!)
+# 5. if you want to test that the folder exists, run nfp "<UNC_path>" test
+
+FILER_ROOT=""
+LOCAL_FILER_PATH=""
+
+function nfp() {
+
+  echo "<=============================" 
+  echo "Root filer folder: $FILER_ROOT" 
+  echo "Input path: $1"
+  echo
+
+  # must double slashes for root filer
+  norm_root=$(echo ${FILER_ROOT} | sed "s|\\\\|\\\\\\\\|g")
+
+  #echo $norm_root
+
+  norm_path=$(echo $1 | sed -e "s|${norm_root}|${LOCAL_FILER_PATH}|" -e  "s|\\\\|/|g")
+
+  echo "=============================>" 
+  echo "Normalized path: ${norm_path}"
+
+  if [ "test" == "$2" ]
+    then
+        echo "Test:"
+        ls -la ${norm_path}
+  fi
+}


### PR DESCRIPTION
# Description

Adds https://gitlab.k8s.cloud.statcan.ca/-/snippets/561 to our images by default.

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
