### PR TITLE
chore(ulimit): set to 0 for core dumps

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -13,8 +13,6 @@ RUN apt-get update --yes \
 COPY suspend-server.sh /usr/local/bin
 COPY adjust-server-resources.py /usr/local/bin
 
-RUN ulimit -c 0
-
 # https://github.com/StatCan/aaw-kubeflow-containers/issues/293
 RUN mamba install --quiet \
       'pillow' \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -13,8 +13,7 @@ RUN apt-get update --yes \
 COPY suspend-server.sh /usr/local/bin
 COPY adjust-server-resources.py /usr/local/bin
 
-RUN ulimit -c 0 \
-  && ulimit -S 0
+RUN ulimit -c 0
 
 # https://github.com/StatCan/aaw-kubeflow-containers/issues/293
 RUN mamba install --quiet \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update --yes \
 COPY suspend-server.sh /usr/local/bin
 COPY adjust-server-resources.py /usr/local/bin
 
+RUN ulimit -c 0 \
+  && ulimit -S 0
+
 # https://github.com/StatCan/aaw-kubeflow-containers/issues/293
 RUN mamba install --quiet \
       'pillow' \

--- a/images/cmd/start-custom.sh
+++ b/images/cmd/start-custom.sh
@@ -262,7 +262,9 @@ if [ -d "$DIR" ]; then
   echo "Permissions for $DIR set to 700."
 fi
 
+# Prevent core dump file creation by setting it to 0. Else can fill up user volumes without them knowing
 ulimit -c 0 
+
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \

--- a/images/cmd/start-custom.sh
+++ b/images/cmd/start-custom.sh
@@ -262,7 +262,7 @@ if [ -d "$DIR" ]; then
   echo "Permissions for $DIR set to 700."
 fi
 
-
+ulimit -c 0 
 echo "--------------------starting jupyter--------------------"
 
 /opt/conda/bin/jupyter server --notebook-dir=/home/${NB_USER} \


### PR DESCRIPTION
For https://jirab.statcan.ca/browse/BTIS-842
Just setting to 0, according to the [man page](https://ss64.com/bash/ulimit.html), 
```
When setting new limits, if neither '-H' nor '-S' is supplied, both the hard and soft limits are set.
```