### PR TITLE
Add oracle lang

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -163,3 +163,5 @@ COPY dbConnection/*.ora /opt/oracle/instantclient_23_5/network/admin/
 #give users permissions to edit the alias file
 RUN chmod a+w /opt/oracle/instantclient_23_5/network/admin
 RUN chown $NB_UID:$NB_GID /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora
+
+ENV NLS_LANG="AMERICAN_AMERICA.WE8MSWIN1252"

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -163,5 +163,5 @@ COPY dbConnection/*.ora /opt/oracle/instantclient_23_5/network/admin/
 #give users permissions to edit the alias file
 RUN chmod a+w /opt/oracle/instantclient_23_5/network/admin
 RUN chown $NB_UID:$NB_GID /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora
-
+# Adds the locale behavior for Oracle
 ENV NLS_LANG="AMERICAN_AMERICA.WE8MSWIN1252"

--- a/images/cmd/start-custom.sh
+++ b/images/cmd/start-custom.sh
@@ -153,6 +153,8 @@ export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 # Have NB_PREFIX and NB_NAMESPACE available in R and Rstudio
 echo "NB_PREFIX=${NB_PREFIX}" >> /opt/conda/lib/R/etc/Renviron
 echo "NB_NAMESPACE=$NB_NAMESPACE" >> /opt/conda/lib/R/etc/Renviron
+# Have the NLS_LANG setting available in R and Rstudio
+echo "NLS_LANG=$NLS_LANG" >> /opt/conda/lib/R/etc/Renviron
 
 # change python location for vscode
 pythonInterpreterPath='{"python.defaultInterpreterPath": "/opt/conda/bin/python"}'


### PR DESCRIPTION
# Description

fixes https://jirab.statcan.ca/browse/BTIS-834

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [x] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [x] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?


**Tested with image** `artifactory.cloud.statcan.ca/das-aaw-docker/jupyterlab-cpu:d2fc314eca1f80440c48d5bdbcb9ecebc2ff5613`
