### PR TITLE
Add tools for working with filers

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -13,6 +13,17 @@ RUN apt-get update --yes \
 COPY suspend-server.sh /usr/local/bin
 COPY adjust-server-resources.py /usr/local/bin
 
+COPY filers_common.py /usr/local/bin
+COPY filer-get.py /usr/local/bin
+COPY filer-mc-cp.py /usr/local/bin
+COPY filer-mc-init.py /usr/local/bin
+COPY filer-mc-ls.py /usr/local/bin
+COPY filer-mc-path.py /usr/local/bin
+COPY filer-mkdir.py /usr/local/bin
+COPY filer-put.py /usr/local/bin
+COPY filer-rm.py /usr/local/bin
+COPY filer-rmdir.py /usr/local/bin
+
 # https://github.com/StatCan/aaw-kubeflow-containers/issues/293
 RUN mamba install --quiet \
       'pillow' \

--- a/images/base/filer-get
+++ b/images/base/filer-get
@@ -1,0 +1,104 @@
+#!/opt/conda/bin/python
+"""
+Get individual file from a filer share and copy to local file.
+"""
+
+import argparse
+import os
+import re
+import sys
+import botocore.session
+from filers_common import get_filer_env_config
+
+
+def get_filer(source_filer_path: str, dest_local_path: str) -> int:
+    "Copy specified file on filer S3 interface to local, using botocore."
+
+    print(
+        f'Download file on filer "{source_filer_path}" to local path "{dest_local_path}".'
+    )
+
+    # Get the filer S3 configuration.
+    url, access_key, secret_key, bucket_name, object_key = get_filer_env_config(
+        source_filer_path
+    )
+
+    try:
+        # Validate source path.
+        if object_key is None:
+            raise OSError("Must specify specific file for download.")
+
+        # Validate destination path.
+        if len(dest_local_path) == 0:
+            raise OSError("Missing destination path, use ./ for current directory.")
+
+        # If final output ends in /, put as file within folder.
+        if dest_local_path[-1] == "/":
+            dest_local_path += re.sub(r".*\/", "", source_filer_path)
+
+        # Connect to filer S3 interface.
+        session = botocore.session.get_session()
+        s3_client = session.create_client(
+            "s3",
+            endpoint_url=url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+        )
+
+        # Copy the object to local path, in 8 MiB chunks.
+        response = s3_client.get_object(Bucket=bucket_name, Key=object_key)
+
+        with open(dest_local_path, "wb") as data:
+            for chunk in response["Body"].iter_chunks(8388608):
+                data.write(chunk)
+
+        # Status of operation.
+        status_str = "Successfully downloaded the file"
+        exit_code = 0
+    except OSError as e:
+        # Print details of error.
+        print("Error occurred when attempting to download file:", e)
+
+        # Remove any partially downloaded file if present.
+        try:
+            os.remove(dest_local_path)
+            print("Removed partially created local file:", dest_local_path)
+        except OSError:
+            pass
+
+        # Status of operation.
+        status_str = "Failed to download the file"
+        exit_code = 1
+
+    # Print info about operation.
+    print(
+        (
+            f'{status_str} the remote file "{source_filer_path}" on NetApp CVO filer '
+            f'to local path "{dest_local_path}"; with endpoint URL {url}; '
+            f'bucket {bucket_name}; object key "{object_key}".'
+        )
+    )
+    return exit_code
+
+
+def main():
+    "Invoked when running filer-get from command line."
+    cmd_parser = argparse.ArgumentParser(
+        description="Copy file from filer to local path."
+    )
+    cmd_parser.add_argument("source_filer_path", help="path to source filer file")
+    cmd_parser.add_argument(
+        "dest_local_path",
+        help=(
+            "path to destination local file, if directory use "
+            "same filename as source within the directory"
+        ),
+    )
+    args = cmd_parser.parse_args()
+
+    r = get_filer(args.source_filer_path, args.dest_local_path)
+    sys.exit(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filer-mc-cp
+++ b/images/base/filer-mc-cp
@@ -1,0 +1,101 @@
+#!/opt/conda/bin/python
+"""
+Copy files to / from filer, using mc cp.
+"""
+
+import argparse
+import os
+import sys
+import subprocess
+
+from filers_common import init_all_filers, get_mc_path, check_filer_path
+
+
+def copy_filer(
+    source_path: str,
+    dest_path: str,
+    recursive: bool = False,
+    indicate_init_done_file: str = "/tmp/_filer_minio_client_init.done",
+) -> int:
+    "Copy files to / from filer, using MinIO client."
+
+    # Print info.
+    rec_str = " recursively" if recursive else ""
+    print(f'Copy "{source_path}" to "{dest_path}"{rec_str}.')
+
+    # Initialize MinIO client aliases to filers.
+    if not os.path.exists(indicate_init_done_file):
+        print("Need to initialize MinIO filer aliases.")
+        init_all_filers()
+    else:
+        print(
+            (
+                "Skip filer alias initialization as indicator file"
+                f" {indicate_init_done_file} already exists."
+            )
+        )
+
+    # Check if each path is to filer, and if so, get MinIO path.
+    if check_filer_path(source_path):
+        source_path = get_mc_path(source_path)
+        print("Converted source path to MinIO path:", source_path)
+
+    if check_filer_path(dest_path):
+        dest_path = get_mc_path(dest_path)
+        print("Converted destination path to MinIO path:", dest_path)
+
+    # Command: build as list, supporting additional options.
+    cmd = ["mc", "cp", "--disable-multipart"]
+    if recursive:
+        cmd.append("--recursive")
+    cmd.append(source_path)
+    cmd.append(dest_path)
+
+    # Run the mc ls command.
+    r = subprocess.run(
+        cmd,
+        check=False,
+    )
+
+    # Print info.
+    if r.returncode != 0:
+        print(f"Error occurred running mc cp command, return code {r.returncode}.")
+    else:
+        print("Successfully performed the copy using mc cp.")
+    return r.returncode
+
+
+def main():
+    "Invoked when running filer-mc-cp from command line."
+    cmd_parser = argparse.ArgumentParser(
+        description="Copy files to / from filer, using mc cp."
+    )
+    cmd_parser.add_argument("source_path", help="path of source file")
+    cmd_parser.add_argument("dest_path", help="path of destination file")
+    cmd_parser.add_argument(
+        "-r",
+        "--recursive",
+        help="copy recursively",
+        action="store_true",
+    )
+    cmd_parser.add_argument(
+        "--indicate-init-done-file",
+        help=(
+            "file that indicates initialization command as been executed, "
+            "default /tmp/_filer_minio_client_init.done"
+        ),
+        default="/tmp/_filer_minio_client_init.done",
+    )
+    args = cmd_parser.parse_args()
+
+    r = copy_filer(
+        args.source_path,
+        args.dest_path,
+        recursive=args.recursive,
+        indicate_init_done_file=args.indicate_init_done_file,
+    )
+    sys.exit(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filer-mc-init
+++ b/images/base/filer-mc-init
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Set MinIO Client aliases for each filer share.
+"""
+
+import argparse
+from filers_common import init_all_filers
+
+
+def main():
+    "Invoked when running filer-mc-init from command line."
+
+    cmd_parser = argparse.ArgumentParser(
+        description="Set MinIO Client aliases for each filer share."
+    )
+    cmd_parser.add_argument(
+        "-q",
+        "--quiet",
+        help="suppress printing of output",
+        action="store_true",
+    )
+    cmd_parser.add_argument(
+        "--indicate-init-done-file",
+        help=(
+            "file that indicates initialization command as been executed, "
+            "default /tmp/_filer_minio_client_init.done"
+        ),
+        default="/tmp/_filer_minio_client_init.done",
+    )
+    args = cmd_parser.parse_args()
+
+    init_all_filers(
+        debug_print=not args.quiet,
+        indicate_done_file=args.indicate_init_done_file,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filer-mc-ls
+++ b/images/base/filer-mc-ls
@@ -1,0 +1,121 @@
+#!/opt/conda/bin/python
+"""
+List files on filer with metadata, using mc ls.
+"""
+
+import argparse
+import os
+import sys
+import subprocess
+
+from filers_common import init_all_filers, get_mc_path
+
+
+def list_filer(
+    path: str,
+    recursive: bool = False,
+    summarize: bool = False,
+    json: bool = False,
+    debug_init: bool = False,
+    debug_mc: bool = False,
+    indicate_init_done_file: str = "/tmp/_filer_minio_client_init.done",
+) -> int:
+    "List files within filer directory, using MinIO client."
+
+    # Initialize MinIO client aliases to filers.
+    if not os.path.exists(indicate_init_done_file):
+        init_all_filers(debug_print=debug_init)
+    elif debug_init:
+        print(
+            (
+                "Skip filer alias initialization as indicator file"
+                f" {indicate_init_done_file} already exists."
+            )
+        )
+
+    # Get MinIO path to filer directory.
+    minio_path = get_mc_path(path)
+
+    # Command: build as list, supporting additional options.
+    cmd = [
+        "mc",
+        "ls",
+        minio_path,
+    ]
+
+    if summarize:
+        cmd.append("--summarize")
+    if recursive:
+        cmd.append("--recursive")
+    if json:
+        cmd.append("--json")
+    if debug_mc:
+        cmd.append("--debug")
+
+    # Run the mc ls command.
+    r = subprocess.run(
+        cmd,
+        check=False,
+    )
+
+    if r.returncode != 0:
+        print(f"Error occurred running mc ls command, return code {r.returncode}.")
+    return r.returncode
+
+
+def main():
+    "Invoked when running filer-mc-ls from command line."
+    cmd_parser = argparse.ArgumentParser(
+        description="List files on filer with metadata, using mc ls."
+    )
+    cmd_parser.add_argument("path", help="path to filer directory, file, or prefix")
+    cmd_parser.add_argument(
+        "-r",
+        "--recursive",
+        help="display summary information (number of objects, total size)",
+        action="store_true",
+    )
+    cmd_parser.add_argument(
+        "--summarize",
+        help="display summary information (number of objects, total size)",
+        action="store_true",
+    )
+    cmd_parser.add_argument(
+        "--json",
+        help="enable JSON lines formatted output",
+        action="store_true",
+    )
+    cmd_parser.add_argument(
+        "--debug-init",
+        help="show debug information for initialization",
+        action="store_true",
+    )
+    cmd_parser.add_argument(
+        "--debug-mc",
+        help="show debug information for MinIO client",
+        action="store_true",
+    )
+    cmd_parser.add_argument(
+        "--indicate-init-done-file",
+        help=(
+            "file that indicates initialization command as been executed, "
+            "default /tmp/_filer_minio_client_init.done"
+        ),
+        default="/tmp/_filer_minio_client_init.done",
+    )
+    args = cmd_parser.parse_args()
+
+    r = list_filer(
+        args.path,
+        debug_init=args.debug_init,
+        debug_mc=args.debug_mc,
+        recursive=args.recursive,
+        summarize=args.summarize,
+        json=args.json,
+        indicate_init_done_file=args.indicate_init_done_file,
+    )
+    sys.exit(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filer-mc-path
+++ b/images/base/filer-mc-path
@@ -1,0 +1,29 @@
+#!/opt/conda/bin/python
+"""
+Get MinIO client path for specified filer location.
+"""
+
+import argparse
+from filers_common import get_mc_path
+
+
+def show_mc_path(path: str):
+    """
+    Print MinIO client path for specified input path.
+    """
+    print(get_mc_path(path))
+
+
+def main():
+    "Invoked when running filer-mc-path from command line."
+    cmd_parser = argparse.ArgumentParser(
+        description="Get MinIO client path for filer location."
+    )
+    cmd_parser.add_argument("path", help="filer path to convert to mc format")
+    args = cmd_parser.parse_args()
+
+    show_mc_path(args.path)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filer-mkdir
+++ b/images/base/filer-mkdir
@@ -1,0 +1,77 @@
+#!/opt/conda/bin/python
+"""
+Create directory on a filer share.
+"""
+
+import argparse
+import sys
+import botocore.session
+from filers_common import get_filer_env_config
+
+
+def mkdir_filer(path: str):
+    "Create directory on filer S3 interface, using botocore."
+
+    print("Create directory on filer, with full path:", path)
+
+    # Get the filer S3 configuration.
+    url, access_key, secret_key, bucket_name, object_key = get_filer_env_config(path)
+
+    try:
+        # Some adjustments for mkdir.
+        if object_key is None or len(object_key) == 0:
+            raise OSError("Cannot create root of filer.")
+        if object_key[-1] != "/":
+            object_key = object_key + "/"
+
+        # Connect to filer S3 interface.
+        session = botocore.session.get_session()
+        s3_client = session.create_client(
+            "s3",
+            endpoint_url=url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+        )
+
+        # Create an empty object (NetApp CVO way to create directory).
+        s3_client.put_object(
+            Body=b"",
+            Bucket=bucket_name,
+            Key=object_key,
+            ChecksumAlgorithm="SHA256",
+            ChecksumSHA256="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        )
+
+        # Status of operation.
+        status_str = "Successfully created"
+        exit_code = 0
+    except OSError as e:
+        # Print details of error.
+        print("Error occurred when attempting to create directory:", e)
+
+        # Status of operation.
+        status_str = "Failed to create"
+        exit_code = 1
+
+    # Print info about operation.
+    print(
+        (
+            f'{status_str} the directory "{path}" on NetApp CVO filer; with endpoint URL {url}; '
+            f'bucket {bucket_name}; object key "{object_key}".'
+        )
+    )
+    return exit_code
+
+
+def main():
+    "Invoked when running filer-mkdir from command line."
+    cmd_parser = argparse.ArgumentParser(description="Create directory on filer.")
+    cmd_parser.add_argument("path", help="path to directory to create")
+    args = cmd_parser.parse_args()
+
+    r = mkdir_filer(args.path)
+    sys.exit(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filer-put
+++ b/images/base/filer-put
@@ -1,0 +1,103 @@
+#!/opt/conda/bin/python
+"""
+Upload local file to filer.
+"""
+
+import argparse
+import hashlib
+import re
+import sys
+import botocore.session
+from filers_common import get_filer_env_config
+
+
+def put_filer(source_local_path: str, dest_filer_path: str) -> int:
+    "Copy specified local file to filer via S3 interface, using botocore."
+
+    print(f'Upload local file "{source_local_path}" to filer path "{dest_filer_path}".')
+
+    # Get the filer S3 configuration.
+    url, access_key, secret_key, bucket_name, object_key = get_filer_env_config(
+        dest_filer_path
+    )
+    digest = "unknown"
+
+    try:
+        # Validate and adjust destination path.
+        if bucket_name is None:
+            raise OSError("Must specify valid share for upload.")
+        if object_key is None or len(object_key) == 0:
+            object_key = "/"
+
+        # If final output ends in /, put as file within folder.
+        if object_key[-1] == "/":
+            fn = re.sub(r".*\/", "", source_local_path)
+            dest_filer_path += fn
+            object_key += fn
+
+        # Get the SHA256 checksum.
+        with open(source_local_path, "rb") as f:
+            digest = hashlib.file_digest(f, "sha256").hexdigest()
+
+        # Connect to filer S3 interface.
+        session = botocore.session.get_session()
+        s3_client = session.create_client(
+            "s3",
+            endpoint_url=url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+        )
+
+        # Upload the object to filer.
+        with open(source_local_path, "rb") as f:
+            s3_client.put_object(
+                Body=f,
+                Bucket=bucket_name,
+                Key=object_key,
+                ChecksumAlgorithm="SHA256",
+                ChecksumSHA256=digest,
+            )
+
+        # Status of operation.
+        status_str = "Successfully uploaded the file"
+        exit_code = 0
+    except OSError as e:
+        # Print details of error.
+        print("Error occurred when attempting to upload file:", e)
+
+        # Status of operation.
+        status_str = "Failed to upload the file"
+        exit_code = 1
+
+    # Print info about operation.
+    print(
+        (
+            f'{status_str} the local file "{source_local_path}" to remote path '
+            f'"{dest_filer_path}" on NetApp CVO filer; with SHA checksum {digest}; '
+            f'endpoint URL {url}; bucket {bucket_name}; object key "{object_key}".'
+        )
+    )
+    return exit_code
+
+
+def main():
+    "Invoked when running filer-put from command line."
+    cmd_parser = argparse.ArgumentParser(
+        description="Copy file from local path to filer."
+    )
+    cmd_parser.add_argument("source_local_path", help="path to source local file")
+    cmd_parser.add_argument(
+        "dest_filer_path",
+        help=(
+            "path to destination filer file, if directory use "
+            "same filename as source within the directory"
+        ),
+    )
+    args = cmd_parser.parse_args()
+
+    r = put_filer(args.source_local_path, args.dest_filer_path)
+    sys.exit(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filer-rm
+++ b/images/base/filer-rm
@@ -1,0 +1,71 @@
+#!/opt/conda/bin/python
+"""
+Remove individual file from a filer share.
+"""
+
+import argparse
+import sys
+import botocore.session
+from filers_common import get_filer_env_config
+
+
+def rm_filer(path: str) -> int:
+    "Remove specified file on filer S3 interface, using botocore."
+
+    print("Remove file on filer, with full path:", path)
+
+    # Get the filer S3 configuration.
+    url, access_key, secret_key, bucket_name, object_key = get_filer_env_config(path)
+
+    try:
+        # Validate path.
+        if object_key is None or len(object_key) == 0:
+            raise OSError("Cannot remove root of filer.")
+
+        # Connect to filer S3 interface.
+        session = botocore.session.get_session()
+        s3_client = session.create_client(
+            "s3",
+            endpoint_url=url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+        )
+
+        # Remove the object.
+        s3_client.delete_object(Bucket=bucket_name, Key=object_key)
+
+        # Status of operation.
+        status_str = "Successfully removed the file"
+        exit_code = 0
+    except OSError as e:
+        # Print details of error.
+        print("Error occurred when attempting to remove file:", e)
+
+        # Status of operation.
+        status_str = "Failed to remove the file"
+        exit_code = 1
+
+    # Print info about operation.
+    print(
+        (
+            f'{status_str} the file "{path}" on NetApp CVO filer; with endpoint URL {url}; '
+            f'bucket {bucket_name}; object key "{object_key}".'
+        )
+    )
+    return exit_code
+
+
+def main():
+    "Invoked when running filer-rm from command line."
+    cmd_parser = argparse.ArgumentParser(
+        description="Remove individual file from filer."
+    )
+    cmd_parser.add_argument("path", help="path to file to remove")
+    args = cmd_parser.parse_args()
+
+    r = rm_filer(args.path)
+    sys.exit(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filer-rmdir
+++ b/images/base/filer-rmdir
@@ -1,0 +1,73 @@
+#!/opt/conda/bin/python
+"""
+Remove empty directory from a filer share.
+"""
+
+import argparse
+import sys
+import botocore.session
+from filers_common import get_filer_env_config
+
+
+def rmdir_filer(path: str) -> int:
+    "Remove empty directory on filer S3 interface, using botocore."
+
+    print("Remove empty directory on filer, with full path:", path)
+
+    # Get the filer S3 configuration.
+    url, access_key, secret_key, bucket_name, object_key = get_filer_env_config(path)
+
+    try:
+        # Some adjustments for rmdir.
+        if object_key is None or len(object_key) == 0:
+            raise OSError("Cannot remove root of filer.")
+        if object_key[-1] != "/":
+            object_key = object_key + "/"
+
+        # Connect to filer S3 interface.
+        session = botocore.session.get_session()
+        s3_client = session.create_client(
+            "s3",
+            endpoint_url=url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+        )
+
+        # Remove the object.
+        s3_client.delete_object(Bucket=bucket_name, Key=object_key)
+
+        # Status of operation.
+        status_str = "Successfully removed empty directory"
+        exit_code = 0
+    except OSError as e:
+        # Print details of error.
+        print("Error occurred when attempting to remove directory:", e)
+
+        # Status of operation.
+        status_str = "Failed to remove empty directory"
+        exit_code = 1
+
+    # Print info about operation.
+    print(
+        (
+            f'{status_str} the directory "{path}" on NetApp CVO filer; with endpoint URL {url}; '
+            f'bucket {bucket_name}; object key "{object_key}".'
+        )
+    )
+    return exit_code
+
+
+def main():
+    "Invoked when running filer-rmdir from command line."
+    cmd_parser = argparse.ArgumentParser(
+        description="Remove empty directory from filer."
+    )
+    cmd_parser.add_argument("path", help="path to directory to remove")
+    args = cmd_parser.parse_args()
+
+    r = rmdir_filer(args.path)
+    sys.exit(r)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/base/filers_common.py
+++ b/images/base/filers_common.py
@@ -1,0 +1,347 @@
+"""
+Common functions and data for using the filers.
+"""
+
+import os
+import re
+import subprocess
+
+
+FILER_ALIASES = {
+    "fld3filersvm": [
+        "assdnt2",
+        "assdnt20",
+        "assdntcad",
+        "fld3file1",
+        "fld3filer",
+    ],
+    "fld4filersvm": [
+        "bop600",
+        "imad3",
+        "imad4",
+        "imaddiskfarm",
+        "meaddata",
+        "pid6",
+        "fld4filer",
+    ],
+    "fld5filersvm": [
+        "agric",
+        "btsapps",
+        "btssce",
+        "dtd1",
+        "iofd1",
+        "itd1lm",
+        "itd3lm",
+        "mced1nt",
+        "mced2nt",
+        "pipes1",
+        "pricesfp01",
+        "serv01",
+        "serv02",
+        "servtax",
+        "sieid2",
+        "fld5filer",
+        "tranfs",
+    ],
+    "fld6filersvm": [
+        "brd2",
+        "brdfcdm",
+        "geo",
+        "geoapps",
+        "geodepot2",
+        "geoenterprise",
+        "meth1",
+        "meth4",
+        "ottfifp03",
+        "ottfifp04",
+        "stds1",
+        "fld6filer",
+    ],
+    "fld7filersvm": [
+        "alpha",
+        "eit-awsfs-dev1",
+        "g-spec",
+        "mtlfp01",
+        "oidhome",
+        "oidnt6",
+        "oidnt7",
+        "ordd1",
+        "orddghost",
+        "rob1",
+        "rob3",
+        "robweb",
+        "yeti-awsfs-dev1",
+        "fld7filer",
+    ],
+    "fld8filersvm": [
+        "ccjsnt1",
+        "co1",
+        "codalg3",
+        "codcola",
+        "codfile",
+        "csmp",
+        "ctces01",
+        "ctces02",
+        "dem4",
+        "eit-awsfs-stg1",
+        "hfss3",
+        "lhs1",
+        "lhs2",
+        "lhs3",
+        "lhs4",
+        "lhs5",
+        "lhs6",
+        "saad1",
+        "sasd6",
+        "fld8filer",
+    ],
+    "fld9filersvm": [
+        "blmamwnt",
+        "hamg1",
+        "hlth",
+        "hlth_apps",
+        "hlth_projects",
+        "hlth_users",
+        "semg1",
+        "fld9filer",
+    ],
+    "stcffb03svm": [
+        "stcffb03",
+        "eit-bwsfs-dev1",
+        "f6stcffb01",
+        "stcffb01",
+        "yeti-bwsfs-dev1",
+    ],
+    "stdcflr_sasfs10svm": [
+        "stdcflr-sasfs10",
+    ],
+    "stdcflr_sasfs20svm": [
+        "sttcflr-sasfs20",
+        "ibspdatatest",
+    ],
+    "stmcflr_sasfs61svm": [
+        "stmcflr-sasfs61",
+        "ibspdatamgmt",
+    ],
+    "stpcflr_sasfs50svm": [
+        "stpcflr-sasfs50",
+        "f8lad",
+        "ibspdata",
+    ],
+    "stqcflr_sasfs40svm": [
+        "stqcflr-sasfs40",
+        "ibspdataqa",
+    ],
+    "sttcflr_sasfs10svm": [
+        "ibspdatadev",
+    ],
+    "stucflr_sasfs30svm": [
+        "stucflr-sasfs30",
+        "ibspdatauat",
+    ],
+    "taxfilersvm": [
+        "taxfiler",
+        "taxadmin",
+    ],
+}
+
+
+def process_filer_path(path: str) -> str:
+    """
+    Remove various leading prefixes from filer path.
+    """
+    path = re.sub(r"\\", "/", path)
+    path = re.sub(r"^[\/\.]*home[\/]+", "", path, flags=re.IGNORECASE)
+    path = re.sub(r"^[\/\.]*jovyan[\/]+", "", path, flags=re.IGNORECASE)
+    path = re.sub(r"^[\/\.]*filers{0,1}[\/]+", "", path, flags=re.IGNORECASE)
+    path = re.sub(r"^[\/\.]*", "", path)
+    return path
+
+
+def remap_filer_aliases(filer: str) -> str:
+    """
+    Remap aliases for filer.
+    """
+    filer = filer.lower()
+    for k, v in FILER_ALIASES.items():
+        if filer in v:
+            return k
+    return filer
+
+
+def get_components(path: str) -> str:
+    "Get name of filer, share, and object key, from path."
+
+    # First need to cleanup the path.
+    path = process_filer_path(path)
+
+    # Now can get the filer, share name, and object name.
+    components = path.split("/", maxsplit=2)
+
+    if len(components) == 0:
+        # Root directory after preprocessing, filer unknown.
+        return None, None, None
+
+    # Filer name is known.
+    filer = remap_filer_aliases(components[0])
+
+    if len(components) == 1:
+        # Missing share name.
+        return filer, None, None
+
+    # Share name is known.
+    share = components[1]
+
+    if len(components) == 2:
+        # Missing object key.
+        return filer, share, None
+
+    # Remove leading slashes from object key.
+    object_key = components[2].lstrip("/")
+    return filer, share, object_key
+
+
+def get_filer_env_config(path: str):
+    "Get configuration from environment variables for specified filer."
+
+    filer_name, share_name, object_key = get_components(path)
+
+    url = os.environ[f"{filer_name}_url"] if filer_name is not None else None
+    access_key = os.environ[f"{filer_name}_access"] if filer_name is not None else None
+    secret_key = os.environ[f"{filer_name}_secret"] if filer_name is not None else None
+    bucket_name = (
+        os.environ[f"{filer_name}_{share_name}"] if share_name is not None else None
+    )
+
+    return url, access_key, secret_key, bucket_name, object_key
+
+
+def get_all_filers() -> list:
+    """
+    Get list of all filers from environment variables.
+    For each filer, get dictionary with:
+    * base
+    * url
+    * access_key
+    * secret_key
+    """
+
+    # Get list of filer bases.
+    url_keys = filter(lambda s: re.match(r"^(.*filersvm|st.*svm)_url$", s), os.environ)
+    all_bases = [re.sub(r"_url$", "", url) for url in url_keys]
+
+    # Return dictionary for each filer base.
+    return [
+        {
+            "base": base,
+            "url": os.getenv(f"{base}_url"),
+            "access_key": os.getenv(f"{base}_access"),
+            "secret_key": os.getenv(f"{base}_secret"),
+        }
+        for base in all_bases
+    ]
+
+
+def init_all_filers(
+    debug_print: bool = True,
+    indicate_done_file: str = "/tmp/_filer_minio_client_init.done",
+):
+    """
+    Sets the MinIO client alias for each filer.
+    """
+
+    if debug_print:
+        print("Set MinIO client alias for each filer...")
+    filers = get_all_filers()
+    nf = len(filers)
+    if debug_print:
+        print(f"Found {nf} filers to initialize.")
+
+    for filer in filers:
+        alias_name = filer["base"]
+        url = filer["url"]
+        if debug_print:
+            print(f"Add filer {alias_name} with url {url}.")
+
+        r = subprocess.run(
+            [
+                "mc",
+                "alias",
+                "set",
+                alias_name,
+                url,
+                filer["access_key"],
+                filer["secret_key"],
+            ],
+            check=False,
+            stdout=None if debug_print else subprocess.DEVNULL,
+            stderr=None if debug_print else subprocess.DEVNULL,
+        )
+
+        if debug_print:
+            if r.returncode == 0:
+                print(f"Successfully added filer {alias_name}.")
+            else:
+                print(
+                    f"Failed to add filer {alias_name}, command return status {r.returncode}."
+                )
+
+    try:
+        if debug_print:
+            print(
+                "Create MinIO client initialization done indicator file:",
+                indicate_done_file,
+            )
+        with open(indicate_done_file, "wb") as f:
+            f.write(b"Done mc init.")
+        if debug_print:
+            print("Successfully created the indicator file.")
+    except OSError as e:
+        if debug_print:
+            print("Error in create done indicator file:", e)
+
+
+def get_mc_path(path: str) -> str:
+    """
+    Return the MinIO client path for input path as a string.
+    """
+    # Get the filer, share name, and object name.
+    components = get_components(path)
+    filer_name = components[0]
+    share_name = components[1]
+    object_key = components[2]
+
+    # Some validations.
+    if filer_name is None or len(filer_name) == 0:
+        raise OSError("Missing filer name.")
+    if share_name is None or len(share_name) == 0:
+        raise OSError("Missing share name.")
+
+    # Get necessary processing.
+    bucket = os.getenv(f"{filer_name}_{share_name}")
+    if bucket is None:
+        raise OSError("Bucket for share not found.")
+
+    if object_key is None:
+        object_key = ""
+
+    # Format is: filer_name/bucket/object_key
+    return f"{filer_name}/{bucket}/{object_key}"
+
+
+def check_filer_path(path: str) -> bool:
+    """
+    Return boolean indicating if path is to filer.
+    True if filer path, False if local path.
+    """
+
+    # Use UNIX path separator.
+    path = re.sub(r"\\", "/", path)
+
+    # If UNC path, is to filer.
+    if re.match(r"^\/\/", path):
+        return True
+
+    # Filer paths are those in /home/jovyan/filers/.
+    path = os.path.abspath(path)
+    return bool(re.match(r"^\/home\/jovyan\/filers\/", path))


### PR DESCRIPTION
# Description

Adds a bunch of tools for working with filers directly using S3 (with botocore available in base environment) and using the mc command more easily. Documentation for these tools available on internal GitLab, can be copied to this pull request if you want.

These tools use the Python in the base conda environment since most of them need botocore for the S3 access.

Some tools help automate setting up the mc aliases for the filers (instead of a bunch of copy-pasting needed currently) and listing / copying files given filer paths (either given a regular filer path or a goofys mount path, but converts those into MinIO client paths and uses mc, doesn't depend on the goofys mounts at all). Makes using S3 directly / the MinIO client for things like uploading large files much easier than before.

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
