### PR TITLE
chore(gpg): add timeout for gpg

### DIFF
--- a/images/cmd/start-custom.sh
+++ b/images/cmd/start-custom.sh
@@ -256,13 +256,15 @@ local({
 EOF
 fi
 
-# Set permissions for .gnupg
-DIR="/home/$NB_USER/.gnupg"
-
-if [ -d "$DIR" ]; then
-  chmod 700 "$DIR"
-  echo "Permissions for $DIR set to 700."
+# Create and set the gpg settings during first boot
+if [ ! -f "/home/$NB_USER/.gnupg/gpg-agent.conf" ]; then
+  echo -e "default-cache-ttl 34560000 \nmax-cache-ttl 34560000 \n" > "/home/$NB_USER/.gnupg/gpg-agent.conf"
 fi
+
+# Set permissions on startup
+chmod 700 "/home/$NB_USER/.gnupg"
+echo "Permissions for $DIR set to 700."
+
 
 # Prevent core dump file creation by setting it to 0. Else can fill up user volumes without them knowing
 ulimit -c 0 


### PR DESCRIPTION
# Description

For [BTIS-641](https://jirab.statcan.ca/browse/BTIS-641) extends the timeout as users need to authenticate as themselves when first using their own notebooks anyways. Also because as a result of this the `.gnupg` directory will always exist on a user's environment so we removed the `if dir exists set perms` to just always set the permission
