### PR TITLE
update(sas):Add env var for oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Tests are formatted using typical pytest formats
 
 1. Clone the repository with `git clone https://github.com/StatCan/zone-kubeflow-containers`.
 2. Run `make install-python-dev-venv` to build a development Python virtual environment.
+2.5 Add back from statements in Dockerfiles. 
 3. Build your image using `make build/IMAGENAME DIRECTORY=STAGENAME`,
 e.g. run `make build/base DIRECTORY=base`.
 4. Test your image using automated tests through `make test/IMAGENAME`,

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -165,3 +165,6 @@ RUN chmod a+w /opt/oracle/instantclient_23_5/network/admin
 RUN chown $NB_UID:$NB_GID /opt/oracle/instantclient_23_5/network/admin/tnsnames.ora
 # Adds the locale behavior for Oracle
 ENV NLS_LANG="AMERICAN_AMERICA.WE8MSWIN1252"
+ENV LD_LIBRARY_PATH = "/opt/oracle/instantclient_23_5"
+ENV TNS_ADMIN="/opt/oracle/instantclient_23_5/network/admin"
+


### PR DESCRIPTION
# Description
Ticket link: https://jirab.statcan.ca/browse/BTIS-756

**What your PR adds/fixes/removes**

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
