### PR TITLE
feat(workflows): Update github workflows for new beta branch

### DIFF
--- a/.github/workflows/check-diff.yaml
+++ b/.github/workflows/check-diff.yaml
@@ -29,17 +29,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch target branch
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-
       - name: Check for changes
         id: check-changes
         if: ${{ github.event_name == 'push' }}
         run: |
           echo "Always build on pushes to master and beta"
           echo "is-diff=true" >> $GITHUB_OUTPUT
+
+      - name: Fetch target branch
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Check for changes
         id: check-changes

--- a/.github/workflows/check-diff.yaml
+++ b/.github/workflows/check-diff.yaml
@@ -17,7 +17,7 @@ on:
         type: string
     outputs:
       is-diff:
-        description: Is there a difference between the master branch and the current branch
+        description: Is there a difference between the target branch and the current branch
         value: ${{ jobs.check-diff.outputs.is-diff }}
 
 jobs:
@@ -29,26 +29,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch master branch
+      - name: Fetch target branch
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
-          git fetch origin master
+          git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Check for changes
         id: check-changes
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "Always build on pushes to master and beta"
+          echo "is-diff=true" >> $GITHUB_OUTPUT
+
+      - name: Check for changes
+        id: check-changes
+        if: ${{ github.event_name == 'pull_request' }}
         run: | # Check for changes excluding README.md
-          if [ "${{ inputs.branch-name }}" == "master" ]; then
-            echo "Always build master"
-            echo "is-diff=true" >> $GITHUB_OUTPUT
-          elif [ "${{ inputs.parent-image-is-diff }}" == "true" ]; then
+          if [ "${{ inputs.parent-image-is-diff }}" == "true" ]; then
             echo "Parent is diff"
             echo "is-diff=true" >> $GITHUB_OUTPUT
           # Check if the subdirectory exists in the base branch
-          elif ! git ls-tree -d origin/master -- "images/${{ inputs.directory }}" >/dev/null 2>&1; then
+          elif ! git ls-tree -d origin/${{ github.event.pull_request.base.ref }} -- "images/${{ inputs.directory }}" >/dev/null 2>&1; then
             echo "Subdirectory does not exist in the base branch"
             echo "is-diff='true'" >> $GITHUB_OUTPUT
           else
-            CHANGES=$(git diff --name-only origin/master HEAD -- "images/${{ inputs.directory }}" | grep -v "README.md" || true)
-            NEW_FILES=$(git diff --name-only --diff-filter=A origin/master HEAD -- "images/${{ inputs.directory }}" | grep -v "README.md" || true)
+            CHANGES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} HEAD -- "images/${{ inputs.directory }}" | grep -v "README.md" || true)
+            NEW_FILES=$(git diff --name-only --diff-filter=A origin/${{ github.event.pull_request.base.ref }} HEAD -- "images/${{ inputs.directory }}" | grep -v "README.md" || true)
             
             CHANGES="${CHANGES}${NEW_FILES}"
 

--- a/.github/workflows/check-diff.yaml
+++ b/.github/workflows/check-diff.yaml
@@ -29,13 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for changes
-        id: check-changes
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          echo "Always build on pushes to master and beta"
-          echo "is-diff=true" >> $GITHUB_OUTPUT
-
       - name: Fetch target branch
         if: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -43,9 +36,11 @@ jobs:
 
       - name: Check for changes
         id: check-changes
-        if: ${{ github.event_name == 'pull_request' }}
         run: | # Check for changes excluding README.md
-          if [ "${{ inputs.parent-image-is-diff }}" == "true" ]; then
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "Always build on pushes to master and beta"
+            echo "is-diff=true" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.parent-image-is-diff }}" == "true" ]; then
             echo "Parent is diff"
             echo "is-diff=true" >> $GITHUB_OUTPUT
           # Check if the subdirectory exists in the base branch

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - "master"
+      - "beta"
     paths:
       - ".github/workflows/*"
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,9 +38,6 @@ jobs:
           BRANCH_NAME=$(./make_helpers/get_branch_name.sh)
           echo "branch-name=$BRANCH_NAME"
           echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-          
-      - name: Set up environment
-        run: echo "Environment has been set up."
 
   base:
     needs: [vars]

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ k8scc01covidacr.azurecr.io/sas              v2         2b9acb795079   19 hours a
 GitHub Actions CI is enabled to do building, scanning, automated testing, pushing of our images to ACR.
 The workflows will trigger on the following:
 
-- any push to master
+- any push to master or beta
 - any push to an open PR that edits files in `.github/workflows/` or `/images/`
 
 This allows for easy scanning and automated testing for images.


### PR DESCRIPTION
# Description

for https://jirab.statcan.ca/browse/BTIS-1008

Also tested using this PR https://github.com/StatCan/zone-kubeflow-containers/pull/71

# Tests / Quality Checks


## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
