### PR TITLE
feat(mid): reorganize Dockerfile for space savings

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -207,17 +207,3 @@ ENV SPARK_HOME="/opt/conda/lib/python3.12/site-packages/pyspark"
 # If using the docker bit in other Dockerfiles, this must get written over in a later layer
 ENV DEFAULT_JUPYTER_URL="/rstudio"
 ENV GIT_EXAMPLE_NOTEBOOKS=https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-r-notebooks.git
-
-# Final cleanup layer
-RUN apt-get clean autoclean \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /var/cache/apt/archives \
-    && rm -rf /tmp/* /var/tmp/* \
-    && find /usr -depth -name '*.pyc' -exec rm -rf '{}' + \
-    && find /usr -depth -name '__pycache__' -exec rm -rfv '{}' + \
-    && conda clean -afy \
-    && npm cache clean --force \
-    && rm -rf /root/.cache /root/.npm \
-    && fix-permissions $CONDA_DIR \
-    && fix-permissions /home/$NB_USER


### PR DESCRIPTION
### Context:

- The JupyterLab image is large and I think we can make it smaller by reorganizing the code inside the Dockerfiles.

### Todo:

- Reorganized code in Mid Dockerfile
- Measure size difference between master and this branch
- Don't change any functionality, only rearrange code, for example: merge related RUN blocks

### Expected Outcome:

- The Dockerfile will retain the same functionality
- Nothing new introduced
- Nothing removed
- Smaller resulting image

### Actual Outcome:

#### Before:

![image](https://github.com/user-attachments/assets/7a0b74ce-4b39-4a5c-80d0-93be739b8044)

Source: https://github.com/StatCan/zone-kubeflow-containers/actions/runs/15687249766/job/44196919258#step:13:1

#### After:

![image](https://github.com/user-attachments/assets/2bedc9a6-a03b-43e4-af02-55231b7ee6af)

- 800MB difference
