### PR TITLE
feat(workflows): Add release creation to beta workflow

### DIFF
--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -73,7 +73,7 @@ jobs:
     - name: check for changes
       run: |
         # get the latest tag
-        latestTag=$(git describe --abbrev=0)
+        latestTag=$(git describe --tags $(git rev-list --tags --max-count=1))
         echo "Latest tag found is: $latestTag"
         echo "latestTag=$latestTag" >> "$GITHUB_ENV"
 
@@ -88,7 +88,7 @@ jobs:
         fi
 
     - name: Create new release release
-      if: env.isDiff
+      if: env.isDiff == 'true'
       run: |
         # returns the current date in YYYY-MM-DD format
         date=$(date +%F) 

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -49,7 +49,6 @@ jobs:
             title=$(echo $prInfo | jq ".title")
             review=$(echo $prInfo | jq ".reviewDecision")
 
-            mergedFlag=false
             # if PR matches all our conditions, merge it
             if [[ "$targetBranch" == '"beta"'
                 && "$mergeState" == '"CLEAN"'
@@ -59,7 +58,6 @@ jobs:
                 
                 echo "Merging PR #$i - $title"
                 gh pr merge $i --delete-branch --squash
-                merged
             else
                 echo "NOT merging PR #$i - $title"
                 echo ""

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -3,6 +3,11 @@ on:
   schedule:
     # Every wednesdays, at 2/3 am(EST/EDT)
     - cron: "0 7 * * WED"
+  pull_request:
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
 
 jobs:
   get-bi-weekly-schedule:
@@ -30,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-tags: true
 
     - name: "Merge ready for beta PRs"
       run: |

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -34,6 +34,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     # - name: "Merge ready for beta PRs"
     #   run: |

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -3,11 +3,6 @@ on:
   schedule:
     # Every wednesdays, at 2/3 am(EST/EDT)
     - cron: "0 7 * * WED"
-  pull_request:
-    types:
-      - 'opened'
-      - 'synchronize'
-      - 'reopened'
 
 jobs:
   get-bi-weekly-schedule:
@@ -37,45 +32,45 @@ jobs:
       with:
         fetch-depth: 0
 
-    # - name: "Merge ready for beta PRs"
-    #   run: |
-    #     # Get list of PR numbers with label "read for beta"
-    #     # pr_list format is "1 24 43 11"
-    #     pr_list=$(gh pr list -l "ready for beta" --json number --jq "[.[].number] | @sh")
+    - name: "Merge ready for beta PRs"
+      run: |
+        # Get list of PR numbers with label "read for beta"
+        # pr_list format is "1 24 43 11"
+        pr_list=$(gh pr list -l "ready for beta" --json number --jq "[.[].number] | @sh")
 
-    #     for i in $pr_list
-    #     do
-    #         # for each PR, get their relevant info
-    #         prInfo=$(gh pr view $i --json baseRefName,mergeStateStatus,isDraft,mergeable,title,reviewDecision)
-    #         targetBranch=$(echo $prInfo | jq ".baseRefName")
-    #         mergeState=$(echo $prInfo | jq ".mergeStateStatus")
-    #         isDraft=$(echo $prInfo | jq ".isDraft")
-    #         isMergeable=$(echo $prInfo | jq ".mergeable")
-    #         title=$(echo $prInfo | jq ".title")
-    #         review=$(echo $prInfo | jq ".reviewDecision")
+        for i in $pr_list
+        do
+            # for each PR, get their relevant info
+            prInfo=$(gh pr view $i --json baseRefName,mergeStateStatus,isDraft,mergeable,title,reviewDecision)
+            targetBranch=$(echo $prInfo | jq ".baseRefName")
+            mergeState=$(echo $prInfo | jq ".mergeStateStatus")
+            isDraft=$(echo $prInfo | jq ".isDraft")
+            isMergeable=$(echo $prInfo | jq ".mergeable")
+            title=$(echo $prInfo | jq ".title")
+            review=$(echo $prInfo | jq ".reviewDecision")
 
-    #         mergedFlag=false
-    #         # if PR matches all our conditions, merge it
-    #         if [[ "$targetBranch" == '"beta"'
-    #             && "$mergeState" == '"CLEAN"'
-    #             && $isDraft == false
-    #             && $isMergeable == '"MERGEABLE"'
-    #             && $review == '"APPROVED"' ]]; then
+            mergedFlag=false
+            # if PR matches all our conditions, merge it
+            if [[ "$targetBranch" == '"beta"'
+                && "$mergeState" == '"CLEAN"'
+                && $isDraft == false
+                && $isMergeable == '"MERGEABLE"'
+                && $review == '"APPROVED"' ]]; then
                 
-    #             echo "Merging PR #$i - $title"
-    #             gh pr merge $i --delete-branch --squash
-    #             merged
-    #         else
-    #             echo "NOT merging PR #$i - $title"
-    #             echo ""
-    #             echo "Target branch should be "beta": is $targetBranch"
-    #             echo "Merge state should be "CLEAN": is $mergeState"
-    #             echo "Should not be in draft. Is draft: $isDraft"
-    #             echo "Should be mergeable. Is mergeable: $isMergeable"
-    #             echo "Should be reviewed. Review is: $review"
-    #         fi
-    #         echo "----------------------------"
-    #     done
+                echo "Merging PR #$i - $title"
+                gh pr merge $i --delete-branch --squash
+                merged
+            else
+                echo "NOT merging PR #$i - $title"
+                echo ""
+                echo "Target branch should be "beta": is $targetBranch"
+                echo "Merge state should be "CLEAN": is $mergeState"
+                echo "Should not be in draft. Is draft: $isDraft"
+                echo "Should be mergeable. Is mergeable: $isMergeable"
+                echo "Should be reviewed. Review is: $review"
+            fi
+            echo "----------------------------"
+        done
 
     - name: check for changes
       run: |
@@ -100,7 +95,7 @@ jobs:
         date=$(date +%F) 
         echo "New tag is $date"
 
-        echo "auto generated release notes will be compared to previous tag $latestTag"
+        echo "Auto generated release notes will be compared to previous tag $latestTag"
 
         # create the release
         gh release create $date --latest --generate-notes --target=beta --notes-start-tag $latestTag

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-tags: true
+        fetch-depth: 0
 
     - name: "Merge ready for beta PRs"
       run: |

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -3,6 +3,11 @@ on:
   schedule:
     # Every wednesdays, at 2/3 am(EST/EDT)
     - cron: "0 7 * * WED"
+  pull_request:
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
 
 jobs:
   get-bi-weekly-schedule:
@@ -30,40 +35,69 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: "Merge ready for beta PRs"
-      run: |
-        # Get list of PR numbers with label "read for beta"
-        # pr_list format is "1 24 43 11"
-        pr_list=$(gh pr list -l "ready for beta" --json number --jq "[.[].number] | @sh")
+    # - name: "Merge ready for beta PRs"
+    #   run: |
+    #     # Get list of PR numbers with label "read for beta"
+    #     # pr_list format is "1 24 43 11"
+    #     pr_list=$(gh pr list -l "ready for beta" --json number --jq "[.[].number] | @sh")
 
-        for i in $pr_list
-        do
-            # for each PR, get their relevant info
-            prInfo=$(gh pr view $i --json baseRefName,mergeStateStatus,isDraft,mergeable,title,reviewDecision)
-            targetBranch=$(echo $prInfo | jq ".baseRefName")
-            mergeState=$(echo $prInfo | jq ".mergeStateStatus")
-            isDraft=$(echo $prInfo | jq ".isDraft")
-            isMergeable=$(echo $prInfo | jq ".mergeable")
-            title=$(echo $prInfo | jq ".title")
-            review=$(echo $prInfo | jq ".reviewDecision")
+    #     for i in $pr_list
+    #     do
+    #         # for each PR, get their relevant info
+    #         prInfo=$(gh pr view $i --json baseRefName,mergeStateStatus,isDraft,mergeable,title,reviewDecision)
+    #         targetBranch=$(echo $prInfo | jq ".baseRefName")
+    #         mergeState=$(echo $prInfo | jq ".mergeStateStatus")
+    #         isDraft=$(echo $prInfo | jq ".isDraft")
+    #         isMergeable=$(echo $prInfo | jq ".mergeable")
+    #         title=$(echo $prInfo | jq ".title")
+    #         review=$(echo $prInfo | jq ".reviewDecision")
 
-            # if PR matches all our conditions, merge it
-            if [[ "$targetBranch" == '"beta"'
-                && "$mergeState" == '"CLEAN"'
-                && $isDraft == false
-                && $isMergeable == '"MERGEABLE"'
-                && $review == '"APPROVED"' ]]; then
+    #         mergedFlag=false
+    #         # if PR matches all our conditions, merge it
+    #         if [[ "$targetBranch" == '"beta"'
+    #             && "$mergeState" == '"CLEAN"'
+    #             && $isDraft == false
+    #             && $isMergeable == '"MERGEABLE"'
+    #             && $review == '"APPROVED"' ]]; then
                 
-                echo "Merging PR #$i - $title"
-                gh pr merge $i --delete-branch --squash
-            else
-                echo "NOT merging PR #$i - $title"
-                echo ""
-                echo "Target branch should be "beta": is $targetBranch"
-                echo "Merge state should be "CLEAN": is $mergeState"
-                echo "Should not be in draft. Is draft: $isDraft"
-                echo "Should be mergeable. Is mergeable: $isMergeable"
-                echo "Should be reviewed. Review is: $review"
-            fi
-            echo "----------------------------"
-        done
+    #             echo "Merging PR #$i - $title"
+    #             gh pr merge $i --delete-branch --squash
+    #             merged
+    #         else
+    #             echo "NOT merging PR #$i - $title"
+    #             echo ""
+    #             echo "Target branch should be "beta": is $targetBranch"
+    #             echo "Merge state should be "CLEAN": is $mergeState"
+    #             echo "Should not be in draft. Is draft: $isDraft"
+    #             echo "Should be mergeable. Is mergeable: $isMergeable"
+    #             echo "Should be reviewed. Review is: $review"
+    #         fi
+    #         echo "----------------------------"
+    #     done
+
+    - name: check for changes
+      run: |
+        latestTag=$(git describe --abbrev=0)
+        echo $latestTag
+        echo "latestTag=$latestTag" >> "$GITHUB_ENV"
+
+        betaDiff=$(git log $latestTag..origin/beta --oneline)
+        echo "Diff is $betaDiff"
+        if [[ -n $betaDiff ]]; then
+          echo "Diff found"
+          echo "isDiff=true" >> "$GITHUB_ENV"
+        else
+          echo "No diff found"
+        fi
+
+    - name: Create new release release
+      if: env.isDiff
+      run: |
+        # returns the current date in YYYY-MM-DD format
+        date=$(date +%F) 
+        echo $date
+
+        echo $latestTag
+
+        # create the release
+        gh release create $date --latest --generate-notes --target=beta --notes-start-tag $latestTag

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -3,11 +3,6 @@ on:
   schedule:
     # Every wednesdays, at 2/3 am(EST/EDT)
     - cron: "0 7 * * WED"
-  pull_request:
-    types:
-      - 'opened'
-      - 'synchronize'
-      - 'reopened'
 
 jobs:
   get-bi-weekly-schedule:

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -79,12 +79,13 @@ jobs:
 
     - name: check for changes
       run: |
+        # get the latest tag
         latestTag=$(git describe --abbrev=0)
-        echo $latestTag
+        echo "Latest tag found is: $latestTag"
         echo "latestTag=$latestTag" >> "$GITHUB_ENV"
 
         betaDiff=$(git log $latestTag..origin/beta --oneline)
-        echo "Diff is $betaDiff"
+        echo "The diff between the latest tag and beta is $betaDiff"
         if [[ -n $betaDiff ]]; then
           echo "Diff found"
           echo "isDiff=true" >> "$GITHUB_ENV"
@@ -97,9 +98,9 @@ jobs:
       run: |
         # returns the current date in YYYY-MM-DD format
         date=$(date +%F) 
-        echo $date
+        echo "New tag is $date"
 
-        echo $latestTag
+        echo "auto generated release notes will be compared to previous tag $latestTag"
 
         # create the release
         gh release create $date --latest --generate-notes --target=beta --notes-start-tag $latestTag

--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -84,6 +84,7 @@ jobs:
           echo "isDiff=true" >> "$GITHUB_ENV"
         else
           echo "No diff found"
+          echo "isDiff=false" >> "$GITHUB_ENV"
         fi
 
     - name: Create new release release


### PR DESCRIPTION
# Description

for https://jirab.statcan.ca/browse/ZONE-44

# Tests / Quality Checks

This is what it looks like after creating the new release
![image](https://github.com/user-attachments/assets/be930603-9642-4664-95f4-718493671fb2)

It was created with the latest run of the workflow.

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
