### PR TITLE
feat: update r and r-studio

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -149,8 +149,8 @@ ENV DEFAULT_JUPYTER_URL=/lab
 ENV GIT_EXAMPLE_NOTEBOOKS=https://gitlab.k8s.cloud.statcan.ca/business-transformation/aaw/aaw-contrib-jupyter-notebooks
 
 # install rstudio-server
-ARG RSTUDIO_VERSION=2024.12.0-467
-ARG SHA256=1493188cdabcc1047db27d1bd0e46947e39562cbd831158c7812f88d80e742b3
+ARG RSTUDIO_VERSION=2025.05.1-513
+ARG SHA256=603c0c7bf0f020e3e1948dd47c82505596139a1aab7890b9020ff3245cc3feff
 RUN apt-get update && \
     apt install -y --no-install-recommends software-properties-common dirmngr gdebi-core && \
     wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc && \
@@ -185,7 +185,7 @@ ENV SPARK_HOME="/opt/conda/lib/python3.12/site-packages/pyspark"
 RUN mamba install --quiet --yes \
       'r-arrow' \
       'r-aws.s3' \
-      'r-base=4.4.1' \
+      'r-base=4.5.1' \
       'r-catools' \
       'r-e1071' \
       'r-hdf5r' \

--- a/tests/general/test_rstudio.py
+++ b/tests/general/test_rstudio.py
@@ -5,7 +5,7 @@ from helpers import CondaPackageHelper
 
 LOGGER = logging.getLogger(__name__)
 
-EXPECTED = "2024.12.0+467 (Kousa Dogwood) for Ubuntu Jammy"
+EXPECTED = "2025.05.1+513 (Mariposa Orchid) for Ubuntu Jammy"
 
 @pytest.fixture(scope="function")
 def package_helper(container):


### PR DESCRIPTION
# Description

update r to latest stable version 4.5.1 (from 4.4.1) and update r studio server to latest stable version 2025.05-513

# Tests / Quality Checks

Pending manual testing.

# Beta Process
- [x] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
