### PR TITLE
fix(Rstudio): added spark_home to Renviron

### DIFF
--- a/images/cmd/start-custom.sh
+++ b/images/cmd/start-custom.sh
@@ -150,11 +150,12 @@ echo "broken configuration settings removed"
 export NB_NAMESPACE=$(echo $NB_PREFIX | awk -F '/' '{print $3}')
 export JWT="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 
-# Have NB_PREFIX and NB_NAMESPACE available in R and Rstudio
+# Setup environment variables for R and Rstudio
 echo "NB_PREFIX=${NB_PREFIX}" >> /opt/conda/lib/R/etc/Renviron
 echo "NB_NAMESPACE=$NB_NAMESPACE" >> /opt/conda/lib/R/etc/Renviron
-# Have the NLS_LANG setting available in R and Rstudio
 echo "NLS_LANG=$NLS_LANG" >> /opt/conda/lib/R/etc/Renviron
+printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
+echo "SPARK_HOME=$SPARK_HOME" >> /opt/conda/lib/R/etc/Renviron
 
 # Revert forced virtualenv, was causing issues with users
 #export PIP_REQUIRE_VIRTUALENV=true
@@ -174,8 +175,6 @@ else
   echo "Creating basic .condarc file"
   printf 'envs_dirs:\n  - $HOME/.conda/envs' > $HOME/.condarc
 fi
-
-printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
 
 # Copy default config and extensions on first start up
 if [ ! -d "$CS_DEFAULT_HOME/Machine" ]; then

--- a/images/cmd/start-custom.sh
+++ b/images/cmd/start-custom.sh
@@ -155,7 +155,7 @@ echo "NB_PREFIX=${NB_PREFIX}" >> /opt/conda/lib/R/etc/Renviron
 echo "NB_NAMESPACE=$NB_NAMESPACE" >> /opt/conda/lib/R/etc/Renviron
 echo "NLS_LANG=$NLS_LANG" >> /opt/conda/lib/R/etc/Renviron
 printenv | grep KUBERNETES >> /opt/conda/lib/R/etc/Renviron
-echo "SPARK_HOME=$SPARK_HOME" >> /opt/conda/lib/R/etc/Renviron
+echo "SPARK_HOME=${SPARK_HOME}" >> /opt/conda/lib/R/etc/Renviron
 
 # Revert forced virtualenv, was causing issues with users
 #export PIP_REQUIRE_VIRTUALENV=true


### PR DESCRIPTION
# Description

Adds the missing `SPARK_HOME` environment variable to the Renviron file so that spark can be executed in Rstudio.

Fixes https://jirab.statcan.ca/browse/ZONE-124

# Tests / Quality Checks

Can be tested with `artifactory.cloud.statcan.ca/das-aaw-docker/jupyterlab-cpu:208e887b`

To test:

1. Open Rstudio
2. Run this code in Rstudio(either one line at a time through the console or with an .R script file):
```
library(sparklyr)
library(tidyverse)

# Initialize Spark connection
sc <- spark_connect(master = "local", app_name = "ZoneSparklyrExample")

# Print Spark version
spark_version(sc)
```

And you should see a version at the end (3.5.5) printed out. You should not see an error.

# Beta Process
- [ ] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
