### PR TITLE
test

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -192,11 +192,13 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Harden rstudio-server
+# https://forum.posit.co/t/stop-the-posit-workbench-login-required-popup-on-rstudio-server/197592 this person having same issues
 RUN mkdir -p /etc/rstudio \
     && echo "www-frame-origin=none" >> /etc/rstudio/rserver.conf \
     && echo "www-enable-origin-check=1" >> /etc/rstudio/rserver.conf \
     && echo "www-same-site=lax" >> /etc/rstudio/rserver.conf \
-    && echo "auth-timeout-minutes=10080" >> /etc/rstudio/rserver.conf  \
+    && echo "auth-timeout-minutes=0" >> /etc/rstudio/rserver.conf  \
+    && echo "auth-stay-signed-in-days=1" >> /etc/rstudio/rserver.conf  \
     && echo "restrict-directory-view=1" >> /etc/rstudio/rsession.conf \
     # Sets the default working dir
     && echo "session-default-working-dir=/home/jovyan/workspace" >> /etc/rstudio/rsession.conf \


### PR DESCRIPTION
# Description
Attempt to fix 
https://jirab.statcan.ca/browse/BTIS-1023

The problem here is that I've tried multiple things here and there but it still persists;
There's this issue for example which shows also what we've tried but [nothing](https://forum.posit.co/t/stop-the-posit-workbench-login-required-popup-on-rstudio-server/197592)

# Tests / Quality Checks


# Beta Process
- [ ] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
