### PR TITLE
feat: disable save workspace prompts by default

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -204,6 +204,7 @@ RUN mkdir -p /etc/rstudio \
     # https://github.com/rstudio/rstudio/issues/14060
     && echo "rsession-ld-library-path=/opt/conda/lib" >> /etc/rstudio/rserver.conf 
 
+# Disables .RData settings
 RUN mkdir -p ${HOME}/.config/rstudio \
     && echo $'{\n\t"save_workspace": "never",\n\t"load_workspace": false\n}' > ${HOME}/.config/rstudio/rstudio-prefs.json
 


### PR DESCRIPTION
# Description

Disables the prompting to save R studio workspace. Apparently it can cause a lot of unexpected behaviour, so it's best to not save.

[Jira](https://jirab.statcan.ca/browse/ZONE-204)

# Tests / Quality Checks


# Beta Process
- [x] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [x] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] ~If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?~

## JupyterLab extensions

- [x] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [x] Does VS Code open?
- [x] Can you install extensions?

## Code review

- [ ] ~Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves~
- [x] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
