### PR TITLE
Feat: add important packages to base

### DIFF
--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -30,20 +30,14 @@ RUN cd ${RESOURCES_PATH} && \
    /bin/bash ./install.sh && \
    rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
 
-# Install system dependencies for r-terra
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libproj-dev \
-    proj-data \
-    proj-bin \
-    gdal-bin \
-    libgdal-dev \
-    && mamba install --quiet --yes -c conda-forge \
+# Install R packages with compatible geospatial libraries
+RUN mamba install --quiet --yes -c conda-forge \
     'r-gt' \
     'r-terra' \
     'r-nloptr' \
+    'proj' \
+    'gdal' \
     && fix-permissions $CONDA_DIR \
-    && fix-permissions /home/$NB_USER \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && fix-permissions /home/$NB_USER
 
 USER $NB_USER

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -34,7 +34,7 @@ RUN mamba install --quiet --yes -c conda-forge \
     'r-gt' \
     'r-terra' \
     'r-nloptr' \
-    'r-nice' \
+    'nice' \
     && clean-layer.sh \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -16,7 +16,7 @@ RUN cd ${RESOURCES_PATH} && \
     tar xf /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar -C ./ && \
     cd ./aocl-linux-aocc-${AOCL_VERSION} && \
     /bin/bash ./install.sh -t /opt/amd/aocl && \
-    cp setenv_aocl.sh ${AOCL_PATH} &&\
+    cp setenv_aocl.sh ${AOCL_PATH} && \
     rm /tmp/aocl-linux-aocc-${AOCL_VERSION}.tar
 
 # Install AMD AOCC
@@ -35,10 +35,14 @@ RUN mamba install --quiet --yes -c conda-forge \
     'r-gt' \
     'r-terra' \
     'r-nloptr' \
-    'r-nice' \
     'proj' \
     'proj-data' \
     'gdal' \
+    && fix-permissions $CONDA_DIR \
+    && fix-permissions /home/$NB_USER
+
+# Install CRAN-only R package: nice
+RUN Rscript -e 'install.packages("nice", repos="https://cloud.r-project.org")' \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -47,6 +47,6 @@ RUN Rscript -e 'install.packages("nice", repos="https://cloud.r-project.org")' \
     && fix-permissions /home/$NB_USER
 
 ENV PROJ_LIB=${CONDA_DIR}/share/proj
-RUN echo "PROJ_LIB=${CONDA_DIR}/share/proj" >> /etc/R/Renviron.site
+RUN echo "PROJ_LIB=${CONDA_DIR}/share/proj" >> /opt/conda/lib/R/etc/Renviron
 
 USER $NB_USER

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -30,5 +30,14 @@ RUN cd ${RESOURCES_PATH} && \
    /bin/bash ./install.sh && \
    rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
 
+RUN mamba install --quiet --yes -c conda-forge \
+    'gt' \
+    'terra' \
+    'nlopptr' \
+    'nice' \
+    && clean-layer.sh \
+    && fix-permissions $CONDA_DIR \
+    && fix-permissions /home/$NB_USER
+
 USER $NB_USER
    

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -42,7 +42,7 @@ RUN mamba install --quiet --yes -c conda-forge \
     && fix-permissions /home/$NB_USER
 
 # Install CRAN-only R package: nice
-RUN Rscript -e 'install.packages("nice", repos="https://cloud.r-project.org")' \
+RUN Rscript -e 'install.packages("nice", repos="https://cloud.r-project.org", lib="/opt/conda/lib/R/library")' \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -34,7 +34,6 @@ RUN mamba install --quiet --yes -c conda-forge \
     'r-gt' \
     'r-terra' \
     'r-nloptr' \
-    'nice' \
     && clean-layer.sh \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -42,7 +42,7 @@ RUN mamba install --quiet --yes -c conda-forge \
     && fix-permissions /home/$NB_USER
 
 # Install CRAN-only R package: nice
-RUN Rscript -e 'install.packages("nice", lib="/opt/conda/lib/R/library")' \
+RUN Rscript -e 'install.packages("nice", repos="https://cloud.r-project.org", lib="/opt/conda/lib/R/library")' \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -23,21 +23,20 @@ RUN cd ${RESOURCES_PATH} && \
 ARG AOCC_VERSION=4.0.0
 ARG AOCC_SHA256=2729ec524cbc927618e479994330eeb72df5947e90cfcc49434009eee29bf7d4
 RUN cd ${RESOURCES_PATH} && \
-   wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
-   echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
-   tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \
-   cd ./aocc-compiler-${AOCC_VERSION} && \
-   /bin/bash ./install.sh && \
-   rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
+    wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
+    echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
+    tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \
+    cd ./aocc-compiler-${AOCC_VERSION} && \
+    /bin/bash ./install.sh && \
+    rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
 
 RUN mamba install --quiet --yes -c conda-forge \
-    'gt' \
-    'terra' \
-    'nlopptr' \
-    'nice' \
+    'r-gt' \
+    'r-terra' \
+    'r-nloptr' \
+    'r-nice' \
     && clean-layer.sh \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 
 USER $NB_USER
-   

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -23,12 +23,12 @@ RUN cd ${RESOURCES_PATH} && \
 ARG AOCC_VERSION=4.0.0
 ARG AOCC_SHA256=2729ec524cbc927618e479994330eeb72df5947e90cfcc49434009eee29bf7d4
 RUN cd ${RESOURCES_PATH} && \
-   wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
-   echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
-   tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \
-   cd ./aocc-compiler-${AOCC_VERSION} && \
-   /bin/bash ./install.sh && \
-   rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
+    wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
+    echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
+    tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \
+    cd ./aocc-compiler-${AOCC_VERSION} && \
+    /bin/bash ./install.sh && \
+    rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
 
 # Install R packages with compatible geospatial libraries
 RUN mamba install --quiet --yes -c conda-forge \
@@ -42,7 +42,7 @@ RUN mamba install --quiet --yes -c conda-forge \
     && fix-permissions /home/$NB_USER
 
 # Install CRAN-only R package: nice
-RUN Rscript -e 'install.packages("nice", repos="https://cloud.r-project.org", lib="/opt/conda/lib/R/library")' \
+RUN Rscript -e 'install.packages("nice", lib="/opt/conda/lib/R/library")' \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -41,11 +41,6 @@ RUN mamba install --quiet --yes -c conda-forge \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 
-# Install CRAN-only R package: nice
-RUN Rscript -e 'install.packages("nice", repos="https://cloud.r-project.org", lib="/opt/conda/lib/R/library")' \
-    && fix-permissions $CONDA_DIR \
-    && fix-permissions /home/$NB_USER
-
 ENV PROJ_LIB=${CONDA_DIR}/share/proj
 RUN echo "PROJ_LIB=${CONDA_DIR}/share/proj" >> /opt/conda/lib/R/etc/Renviron
 

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -23,12 +23,12 @@ RUN cd ${RESOURCES_PATH} && \
 ARG AOCC_VERSION=4.0.0
 ARG AOCC_SHA256=2729ec524cbc927618e479994330eeb72df5947e90cfcc49434009eee29bf7d4
 RUN cd ${RESOURCES_PATH} && \
-    wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
-    echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
-    tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \
-    cd ./aocc-compiler-${AOCC_VERSION} && \
-    /bin/bash ./install.sh && \
-    rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
+   wget --quiet https://download.amd.com/developer/eula/aocc-compiler/aocc-compiler-${AOCC_VERSION}.tar -O /tmp/aocc-compiler-${AOCC_VERSION}.tar && \
+   echo "${AOCC_SHA256} /tmp/aocc-compiler-${AOCC_VERSION}.tar" | sha256sum -c - && \
+   tar xf /tmp/aocc-compiler-${AOCC_VERSION}.tar -C ./ && \
+   cd ./aocc-compiler-${AOCC_VERSION} && \
+   /bin/bash ./install.sh && \
+   rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
 
 RUN mamba install --quiet --yes -c conda-forge \
     'r-gt' \

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -30,11 +30,20 @@ RUN cd ${RESOURCES_PATH} && \
    /bin/bash ./install.sh && \
    rm /tmp/aocc-compiler-${AOCC_VERSION}.tar
 
-RUN mamba install --quiet --yes -c conda-forge \
+# Install system dependencies for r-terra
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libproj-dev \
+    proj-data \
+    proj-bin \
+    gdal-bin \
+    libgdal-dev \
+    && mamba install --quiet --yes -c conda-forge \
     'r-gt' \
     'r-terra' \
     'r-nloptr' \
     && fix-permissions $CONDA_DIR \
-    && fix-permissions /home/$NB_USER
+    && fix-permissions /home/$NB_USER \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 USER $NB_USER

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -35,9 +35,14 @@ RUN mamba install --quiet --yes -c conda-forge \
     'r-gt' \
     'r-terra' \
     'r-nloptr' \
+    'r-nice' \
     'proj' \
+    'proj-data' \
     'gdal' \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
+
+ENV PROJ_LIB=${CONDA_DIR}/share/proj
+RUN echo "PROJ_LIB=${CONDA_DIR}/share/proj" >> /etc/R/Renviron.site
 
 USER $NB_USER

--- a/images/jupyterlab/Dockerfile
+++ b/images/jupyterlab/Dockerfile
@@ -34,7 +34,6 @@ RUN mamba install --quiet --yes -c conda-forge \
     'r-gt' \
     'r-terra' \
     'r-nloptr' \
-    && clean-layer.sh \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 

--- a/tests/general/test_packages.py
+++ b/tests/general/test_packages.py
@@ -107,7 +107,10 @@ EXCLUDED_PACKAGES = [
     # pytables is the package but we import tables
     "tables",
     "pytables",
-    "pkg-config"
+    "pkg-config",
+    # Geospatial packages - cannot be imported directly in standard tests
+    "proj",
+    "gdal",
 ]
 
 

--- a/tests/general/test_packages.py
+++ b/tests/general/test_packages.py
@@ -110,6 +110,7 @@ EXCLUDED_PACKAGES = [
     "pkg-config",
     # Geospatial packages - cannot be imported directly in standard tests
     "proj",
+    "proj-data",
     "gdal",
 ]
 


### PR DESCRIPTION
### Summary

This PR extends the base Conda environment by installing the R packages `gt`, `terra`, and `nloptr` via `mamba`, along with the required geospatial system libraries (`proj`, `proj-data`, `gdal`). These are pulled from conda-forge to ensure ABI compatibility and avoid compiling native dependencies during the image build.

The CRAN-only R package `nice` is installed separately using `Rscript`, since it is not available on conda-forge.

#### Details

- Use `mamba` to install R packages with native dependencies (`terra`, `nloptr`) to avoid runtime compilation issues
- Explicitly install `proj`, `proj-data`, and `gdal` to guarantee consistent PROJ/GDAL behavior across images
- Configure `PROJ_LIB` in Conda R’s `R/etc/Renviron`, matching the existing runtime configuration
- Install `nice` from CRAN using `Rscript`, as it is a pure R package
- No changes to the runtime user or base image assumptions

JIRA: https://jirab.statcan.ca/browse/ZONE-301
