### PR TITLE
add: Add OneLake Mount using Blobfuse2

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -90,26 +90,11 @@ RUN mamba install --quiet --yes -c conda-forge \
     'nb_conda_kernels' \
     'jupyterlab-lsp' \
     'jupyter-lsp' \
-    'r-arrow' \
-    'r-aws.s3' \
-    'r-base=4.5.1' \
-    'r-catools' \
-    'r-e1071' \
-    'r-hdf5r' \
-    'r-markdown' \
-    'r-odbc' \
-    'r-renv' \
-    'r-rodbc' \
-    'r-sf' \
-    'r-sparklyr' \
-    'r-tidyverse' \
     && pip install --no-cache-dir \
     'kubeflow-training' \
     'git+https://github.com/betatim/vscode-binder' \
     'jupyter-rsession-proxy==2.2.0' \
     'pyspark[ml]==3.5.5' \
-    'azure-storage-file-datalake' \
-    'azure-identity' \
     && jupyter server extension enable --py jupyter_server_proxy \
     && jupyter labextension enable \
     '@jupyterlab/translation-extension' \
@@ -136,6 +121,13 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
     && npm cache clean --force \
     && rm -rf /root/.npm \
     && clean-layer.sh \ 
+    && fix-permissions $CONDA_DIR \
+    && fix-permissions /home/$NB_USER
+
+# OneLake SDK for accessing Microsoft Fabric OneLake (ADLS Gen2) storage
+RUN pip install --no-cache-dir \
+    'azure-storage-file-datalake' \
+    'azure-identity' \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -137,6 +137,14 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 
+# OneLake / ADLS Gen2 SDK for accessing Microsoft Fabric OneLake storage
+RUN pip install --no-cache-dir \
+    'azure-storage-file-datalake' \
+    'azure-identity' \
+    && fix-permissions $CONDA_DIR \
+    && fix-permissions /home/$NB_USER
+COPY onelake_utils.py /opt/conda/lib/python3.13/site-packages/onelake_utils.py
+
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
 

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -108,6 +108,8 @@ RUN mamba install --quiet --yes -c conda-forge \
     'git+https://github.com/betatim/vscode-binder' \
     'jupyter-rsession-proxy==2.2.0' \
     'pyspark[ml]==3.5.5' \
+    'azure-storage-file-datalake' \
+    'azure-identity' \
     && jupyter server extension enable --py jupyter_server_proxy \
     && jupyter labextension enable \
     '@jupyterlab/translation-extension' \
@@ -137,12 +139,7 @@ RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 
-# OneLake / ADLS Gen2 SDK for accessing Microsoft Fabric OneLake storage
-RUN pip install --no-cache-dir \
-    'azure-storage-file-datalake' \
-    'azure-identity' \
-    && fix-permissions $CONDA_DIR \
-    && fix-permissions /home/$NB_USER
+# OneLake helper module for accessing Microsoft Fabric OneLake storage
 COPY onelake_utils.py /opt/conda/lib/python3.13/site-packages/onelake_utils.py
 
 # Solarized Theme and Cell Execution Time

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -131,6 +131,14 @@ RUN pip install --no-cache-dir \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 
+# Install blobfuse2 for OneLake FUSE filesystem mount
+# Microsoft apt repo already configured in base image
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends fuse3 blobfuse2 \
+    && echo "user_allow_other" >> /etc/fuse.conf \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # OneLake helper module for accessing Microsoft Fabric OneLake storage
 # Note: Azure CLI is already installed in the base image
 COPY onelake_utils.py /opt/conda/lib/python3.13/site-packages/onelake_utils.py

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -131,12 +131,8 @@ RUN pip install --no-cache-dir \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 
-# Azure CLI for authentication and OneLake access (az login --use-device-code)
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
 # OneLake helper module for accessing Microsoft Fabric OneLake storage
+# Note: Azure CLI is already installed in the base image
 COPY onelake_utils.py /opt/conda/lib/python3.13/site-packages/onelake_utils.py
 
 # Solarized Theme and Cell Execution Time

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -131,6 +131,11 @@ RUN pip install --no-cache-dir \
     && fix-permissions $CONDA_DIR \
     && fix-permissions /home/$NB_USER
 
+# Azure CLI for authentication and OneLake access (az login --use-device-code)
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # OneLake helper module for accessing Microsoft Fabric OneLake storage
 COPY onelake_utils.py /opt/conda/lib/python3.13/site-packages/onelake_utils.py
 

--- a/images/mid/onelake_utils.py
+++ b/images/mid/onelake_utils.py
@@ -22,6 +22,7 @@ Usage:
 import json
 import os
 import re
+import shutil
 from pathlib import Path
 
 # Lazy imports - only loaded on first use to keep import fast
@@ -30,6 +31,12 @@ _fs_client = None
 
 # OneLake DFS endpoint (ADLS Gen2 compatible)
 ONELAKE_ENDPOINT = "https://onelake.dfs.fabric.microsoft.com"
+
+# Persistent config file so connect() survives across processes
+_CONFIG_FILE = Path.home() / ".onelake_config"
+
+# FUSE mount path (set up by s6 init script 04-onelake-mount)
+MOUNT_PATH = Path.home() / "onelake"
 
 # Messages in EN/FR
 _MSG = {
@@ -45,6 +52,10 @@ _MSG = {
         "endpoint": "Endpoint",
         "base_path": "Base path",
         "switched": "Switched to workspace '{ws}', lakehouse '{lh}'",
+        "mount_status": "Mount",
+        "mounted": "Mounted at {path}",
+        "not_mounted": "Not mounted (using SDK)",
+        "mount_warning": "Note: ~/onelake/ mount is tied to boot-time config. SDK will use the new workspace.",
     },
     "fr": {
         "no_workspace": "ONELAKE_WORKSPACE n'est pas defini. Utilisez onelake.connect(workspace='...', lakehouse='...') ou contactez votre admin.",
@@ -58,6 +69,10 @@ _MSG = {
         "endpoint": "Point de terminaison",
         "base_path": "Chemin de base",
         "switched": "Bascule vers l'espace de travail '{ws}', lakehouse '{lh}'",
+        "mount_status": "Montage",
+        "mounted": "Monte a {path}",
+        "not_mounted": "Non monte (utilisation du SDK)",
+        "mount_warning": "Note: ~/onelake/ est lie a la config de demarrage. Le SDK utilisera le nouvel espace.",
     },
 }
 
@@ -74,9 +89,19 @@ def _msg(key):
 
 
 def _get_config():
-    """Read OneLake configuration from environment variables."""
+    """Read OneLake configuration from env vars, falling back to ~/.onelake_config."""
     workspace = os.environ.get("ONELAKE_WORKSPACE", "")
     lakehouse = os.environ.get("ONELAKE_LAKEHOUSE", "")
+    if workspace and lakehouse:
+        return workspace, lakehouse
+    # Fall back to saved config from a previous connect() call
+    if _CONFIG_FILE.exists():
+        try:
+            saved = json.loads(_CONFIG_FILE.read_text())
+            workspace = workspace or saved.get("workspace", "")
+            lakehouse = lakehouse or saved.get("lakehouse", "")
+        except (json.JSONDecodeError, OSError):
+            pass
     return workspace, lakehouse
 
 
@@ -127,6 +152,11 @@ def _is_guid(value):
     ))
 
 
+def _is_mounted():
+    """Check if OneLake is FUSE-mounted at ~/onelake/."""
+    return MOUNT_PATH.is_mount()
+
+
 def _build_path(path, lakehouse=None):
     """Build the full OneLake path including lakehouse prefix.
 
@@ -169,10 +199,20 @@ def connect(workspace, lakehouse):
     global _client, _fs_client
     os.environ["ONELAKE_WORKSPACE"] = workspace
     os.environ["ONELAKE_LAKEHOUSE"] = lakehouse
+    # Save to disk so config persists across terminal sessions
+    try:
+        _CONFIG_FILE.write_text(json.dumps({
+            "workspace": workspace,
+            "lakehouse": lakehouse,
+        }))
+    except OSError:
+        pass
     # Reset cached clients so they reconnect to the new workspace
     _client = None
     _fs_client = None
     print(_msg("switched").format(ws=workspace, lh=lakehouse))
+    if _is_mounted():
+        print(_msg("mount_warning"))
 
 
 def info():
@@ -188,6 +228,8 @@ def info():
     if workspace and lakehouse:
         base = f"{lakehouse}/Files/" if _is_guid(lakehouse) else f"{lakehouse}.Lakehouse/Files/"
         print(f"  {_msg('base_path')}: {base}")
+    mount = _msg("mounted").format(path=MOUNT_PATH) if _is_mounted() else _msg("not_mounted")
+    print(f"  {_msg('mount_status')}: {mount}")
 
 
 def ls(path="/"):
@@ -214,16 +256,28 @@ def ls(path="/"):
 def download(remote_path, local_path):
     """Download a file from OneLake to local filesystem.
 
+    Uses the local FUSE mount if available for faster downloads,
+    otherwise falls back to the SDK.
+
     Args:
         remote_path: Path in OneLake (relative to lakehouse Files/).
         local_path: Local destination path.
     """
+    remote_path = remote_path.lstrip("/")
+    local = Path(local_path)
+    local.parent.mkdir(parents=True, exist_ok=True)
+
+    # Fast path: copy from FUSE mount if available
+    if _is_mounted():
+        mount_file = MOUNT_PATH / remote_path
+        if mount_file.exists():
+            shutil.copy2(str(mount_file), str(local))
+            return
+
+    # Fallback: SDK
     fs = _get_fs_client()
     full_path = _build_path(remote_path)
     file_client = fs.get_file_client(full_path)
-
-    local = Path(local_path)
-    local.parent.mkdir(parents=True, exist_ok=True)
 
     with open(local, "wb") as f:
         data = file_client.download_file()
@@ -248,6 +302,9 @@ def upload(local_path, remote_path):
 def read(path, as_text=False):
     """Read a file from OneLake and return its contents.
 
+    Uses the local FUSE mount if available for faster reads,
+    otherwise falls back to the SDK.
+
     Args:
         path: Path in OneLake (relative to lakehouse Files/).
         as_text: If True, return as string. Otherwise return bytes.
@@ -255,6 +312,15 @@ def read(path, as_text=False):
     Returns:
         File contents as bytes or string.
     """
+    path = path.lstrip("/")
+    # Fast path: read from FUSE mount if available
+    if _is_mounted():
+        local_file = MOUNT_PATH / path
+        if local_file.exists():
+            data = local_file.read_bytes()
+            return data.decode("utf-8") if as_text else data
+
+    # Fallback: SDK
     fs = _get_fs_client()
     full_path = _build_path(path)
     file_client = fs.get_file_client(full_path)

--- a/images/mid/onelake_utils.py
+++ b/images/mid/onelake_utils.py
@@ -1,0 +1,237 @@
+"""
+OneLake utility module for Zone Kubeflow containers.
+
+Provides simple functions to interact with Microsoft OneLake (ADLS Gen2)
+storage from within JupyterLab, VS Code, or any Python environment.
+
+Usage:
+    import onelake_utils as onelake
+
+    onelake.info()              # Show connection status
+    onelake.ls("/")             # List files at root
+    onelake.download("data.csv", "local.csv")
+    onelake.upload("local.csv", "data.csv")
+"""
+
+import json
+import os
+from pathlib import Path
+
+# Lazy imports - only loaded on first use to keep import fast
+_client = None
+_fs_client = None
+
+# OneLake DFS endpoint (ADLS Gen2 compatible)
+ONELAKE_ENDPOINT = "https://onelake.dfs.fabric.microsoft.com"
+
+# Messages in EN/FR
+_MSG = {
+    "en": {
+        "no_workspace": "ONELAKE_WORKSPACE is not set. Contact your admin to enable OneLake for your namespace.",
+        "no_lakehouse": "ONELAKE_LAKEHOUSE is not set. Contact your admin to configure your lakehouse.",
+        "auth_fail": "Authentication failed. Ensure your pod has valid credentials (Workload Identity or SPN).",
+        "connected": "Connected",
+        "not_configured": "Not configured",
+        "status": "Status",
+        "workspace": "Workspace",
+        "lakehouse": "Lakehouse",
+        "endpoint": "Endpoint",
+        "base_path": "Base path",
+    },
+    "fr": {
+        "no_workspace": "ONELAKE_WORKSPACE n'est pas defini. Contactez votre admin pour activer OneLake.",
+        "no_lakehouse": "ONELAKE_LAKEHOUSE n'est pas defini. Contactez votre admin pour configurer votre lakehouse.",
+        "auth_fail": "Echec d'authentification. Verifiez les identifiants du pod (Workload Identity ou SPN).",
+        "connected": "Connecte",
+        "not_configured": "Non configure",
+        "status": "Statut",
+        "workspace": "Espace de travail",
+        "lakehouse": "Lakehouse",
+        "endpoint": "Point de terminaison",
+        "base_path": "Chemin de base",
+    },
+}
+
+
+def _lang():
+    """Return 'fr' if user locale is French, else 'en'."""
+    lang = os.environ.get("LANG", "en_US")
+    return "fr" if lang.startswith("fr") else "en"
+
+
+def _msg(key):
+    """Get a bilingual message."""
+    return _MSG[_lang()].get(key, _MSG["en"].get(key, key))
+
+
+def _get_config():
+    """Read OneLake configuration from environment variables."""
+    workspace = os.environ.get("ONELAKE_WORKSPACE", "")
+    lakehouse = os.environ.get("ONELAKE_LAKEHOUSE", "")
+    return workspace, lakehouse
+
+
+def _get_credential():
+    """Get Azure credential using DefaultAzureCredential (lazy)."""
+    from azure.identity import DefaultAzureCredential
+    return DefaultAzureCredential()
+
+
+def _get_service_client():
+    """Get or create the DataLakeServiceClient (singleton, lazy)."""
+    global _client
+    if _client is not None:
+        return _client
+
+    workspace, lakehouse = _get_config()
+    if not workspace:
+        raise RuntimeError(_msg("no_workspace"))
+
+    from azure.storage.filedatalake import DataLakeServiceClient
+
+    _client = DataLakeServiceClient(
+        account_url=ONELAKE_ENDPOINT,
+        credential=_get_credential(),
+    )
+    return _client
+
+
+def _get_fs_client():
+    """Get or create the FileSystemClient for the user's workspace (singleton, lazy)."""
+    global _fs_client
+    if _fs_client is not None:
+        return _fs_client
+
+    workspace, lakehouse = _get_config()
+    if not workspace:
+        raise RuntimeError(_msg("no_workspace"))
+
+    _fs_client = _get_service_client().get_file_system_client(file_system=workspace)
+    return _fs_client
+
+
+def _build_path(path):
+    """Build the full OneLake path including lakehouse prefix.
+
+    Users pass paths relative to their lakehouse Files directory.
+    e.g., "data.csv" becomes "<lakehouse>.Lakehouse/Files/data.csv"
+    """
+    _, lakehouse = _get_config()
+    if not lakehouse:
+        raise RuntimeError(_msg("no_lakehouse"))
+
+    path = path.lstrip("/")
+    return f"{lakehouse}.Lakehouse/Files/{path}"
+
+
+def info():
+    """Print OneLake connection status."""
+    workspace, lakehouse = _get_config()
+    lang = _lang()
+
+    status = _msg("connected") if (workspace and lakehouse) else _msg("not_configured")
+
+    print(f"  OneLake {_msg('status')}: {status}")
+    print(f"  {_msg('workspace')}: {workspace or 'N/A'}")
+    print(f"  {_msg('lakehouse')}: {lakehouse or 'N/A'}")
+    print(f"  {_msg('endpoint')}: {ONELAKE_ENDPOINT}")
+    if workspace and lakehouse:
+        print(f"  {_msg('base_path')}: {lakehouse}.Lakehouse/Files/")
+
+
+def ls(path="/", workspace=None):
+    """List files and directories at the given path.
+
+    Args:
+        path: Path relative to the lakehouse Files directory. Default "/".
+        workspace: Optional workspace override for cross-workspace access.
+
+    Returns:
+        List of dicts with 'name', 'is_directory', and 'size' keys.
+    """
+    fs = _get_fs_client()
+    if workspace:
+        fs = _get_service_client().get_file_system_client(file_system=workspace)
+
+    full_path = _build_path(path)
+    results = []
+    for item in fs.get_paths(path=full_path):
+        name = item.name
+        # Strip the lakehouse prefix for cleaner display
+        _, lh = _get_config()
+        prefix = f"{lh}.Lakehouse/Files/"
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+        results.append({
+            "name": name,
+            "is_directory": item.is_directory,
+            "size": getattr(item, "content_length", 0),
+        })
+    return results
+
+
+def download(remote_path, local_path):
+    """Download a file from OneLake to local filesystem.
+
+    Args:
+        remote_path: Path in OneLake (relative to lakehouse Files/).
+        local_path: Local destination path.
+    """
+    fs = _get_fs_client()
+    full_path = _build_path(remote_path)
+    file_client = fs.get_file_client(full_path)
+
+    local = Path(local_path)
+    local.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(local, "wb") as f:
+        data = file_client.download_file()
+        data.readinto(f)
+
+
+def upload(local_path, remote_path):
+    """Upload a local file to OneLake.
+
+    Args:
+        local_path: Local file path.
+        remote_path: Destination path in OneLake (relative to lakehouse Files/).
+    """
+    fs = _get_fs_client()
+    full_path = _build_path(remote_path)
+    file_client = fs.get_file_client(full_path)
+
+    with open(local_path, "rb") as f:
+        file_client.upload_data(f, overwrite=True)
+
+
+def read(path, as_text=False):
+    """Read a file from OneLake and return its contents.
+
+    Args:
+        path: Path in OneLake (relative to lakehouse Files/).
+        as_text: If True, return as string. Otherwise return bytes.
+
+    Returns:
+        File contents as bytes or string.
+    """
+    fs = _get_fs_client()
+    full_path = _build_path(path)
+    file_client = fs.get_file_client(full_path)
+    data = file_client.download_file().readall()
+    return data.decode("utf-8") if as_text else data
+
+
+def write(path, data):
+    """Write data to a file on OneLake.
+
+    Args:
+        path: Destination path in OneLake (relative to lakehouse Files/).
+        data: bytes or string to write.
+    """
+    fs = _get_fs_client()
+    full_path = _build_path(path)
+    file_client = fs.get_file_client(full_path)
+
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    file_client.upload_data(data, overwrite=True)

--- a/images/mid/onelake_utils.py
+++ b/images/mid/onelake_utils.py
@@ -9,12 +9,19 @@ Usage:
 
     onelake.info()              # Show connection status
     onelake.ls("/")             # List files at root
+    onelake.read("data.csv")    # Read a file
+    onelake.write("out.csv", d) # Write data
     onelake.download("data.csv", "local.csv")
     onelake.upload("local.csv", "data.csv")
+
+    # Switch workspace/lakehouse on the fly
+    onelake.connect(workspace="<guid>", lakehouse="<guid>")
+    onelake.ls("/")             # Now lists the new workspace
 """
 
 import json
 import os
+import re
 from pathlib import Path
 
 # Lazy imports - only loaded on first use to keep import fast
@@ -27,8 +34,8 @@ ONELAKE_ENDPOINT = "https://onelake.dfs.fabric.microsoft.com"
 # Messages in EN/FR
 _MSG = {
     "en": {
-        "no_workspace": "ONELAKE_WORKSPACE is not set. Contact your admin to enable OneLake for your namespace.",
-        "no_lakehouse": "ONELAKE_LAKEHOUSE is not set. Contact your admin to configure your lakehouse.",
+        "no_workspace": "ONELAKE_WORKSPACE is not set. Use onelake.connect(workspace='...', lakehouse='...') or contact your admin.",
+        "no_lakehouse": "ONELAKE_LAKEHOUSE is not set. Use onelake.connect(workspace='...', lakehouse='...') or contact your admin.",
         "auth_fail": "Authentication failed. Ensure your pod has valid credentials (Workload Identity or SPN).",
         "connected": "Connected",
         "not_configured": "Not configured",
@@ -37,10 +44,11 @@ _MSG = {
         "lakehouse": "Lakehouse",
         "endpoint": "Endpoint",
         "base_path": "Base path",
+        "switched": "Switched to workspace '{ws}', lakehouse '{lh}'",
     },
     "fr": {
-        "no_workspace": "ONELAKE_WORKSPACE n'est pas defini. Contactez votre admin pour activer OneLake.",
-        "no_lakehouse": "ONELAKE_LAKEHOUSE n'est pas defini. Contactez votre admin pour configurer votre lakehouse.",
+        "no_workspace": "ONELAKE_WORKSPACE n'est pas defini. Utilisez onelake.connect(workspace='...', lakehouse='...') ou contactez votre admin.",
+        "no_lakehouse": "ONELAKE_LAKEHOUSE n'est pas defini. Utilisez onelake.connect(workspace='...', lakehouse='...') ou contactez votre admin.",
         "auth_fail": "Echec d'authentification. Verifiez les identifiants du pod (Workload Identity ou SPN).",
         "connected": "Connecte",
         "not_configured": "Non configure",
@@ -49,6 +57,7 @@ _MSG = {
         "lakehouse": "Lakehouse",
         "endpoint": "Point de terminaison",
         "base_path": "Chemin de base",
+        "switched": "Bascule vers l'espace de travail '{ws}', lakehouse '{lh}'",
     },
 }
 
@@ -110,24 +119,65 @@ def _get_fs_client():
     return _fs_client
 
 
-def _build_path(path):
+def _is_guid(value):
+    """Check if a string looks like a GUID/UUID."""
+    return bool(re.match(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+        value, re.IGNORECASE,
+    ))
+
+
+def _build_path(path, lakehouse=None):
     """Build the full OneLake path including lakehouse prefix.
 
     Users pass paths relative to their lakehouse Files directory.
-    e.g., "data.csv" becomes "<lakehouse>.Lakehouse/Files/data.csv"
+    With friendly names: "<name>.Lakehouse/Files/<path>"
+    With GUIDs:          "<guid>/Files/<path>"
     """
-    _, lakehouse = _get_config()
+    if not lakehouse:
+        _, lakehouse = _get_config()
     if not lakehouse:
         raise RuntimeError(_msg("no_lakehouse"))
 
     path = path.lstrip("/")
+    if _is_guid(lakehouse):
+        return f"{lakehouse}/Files/{path}"
     return f"{lakehouse}.Lakehouse/Files/{path}"
+
+
+def _strip_prefix(name, lakehouse=None):
+    """Strip the lakehouse/Files prefix from a path for clean display."""
+    if not lakehouse:
+        _, lakehouse = _get_config()
+    prefix = f"{lakehouse}/Files/" if _is_guid(lakehouse) else f"{lakehouse}.Lakehouse/Files/"
+    if name.startswith(prefix):
+        return name[len(prefix):]
+    return name
+
+
+def connect(workspace, lakehouse):
+    """Switch to a different workspace and lakehouse.
+
+    Args:
+        workspace: Workspace name or GUID.
+        lakehouse: Lakehouse name or GUID.
+
+    Usage:
+        onelake.connect("1dd0411c-...", "88dd60d0-...")
+        onelake.ls("/")  # now lists files in the new workspace
+    """
+    global _client, _fs_client
+    os.environ["ONELAKE_WORKSPACE"] = workspace
+    os.environ["ONELAKE_LAKEHOUSE"] = lakehouse
+    # Reset cached clients so they reconnect to the new workspace
+    _client = None
+    _fs_client = None
+    print(_msg("switched").format(ws=workspace, lh=lakehouse))
 
 
 def info():
     """Print OneLake connection status."""
     workspace, lakehouse = _get_config()
-    lang = _lang()
 
     status = _msg("connected") if (workspace and lakehouse) else _msg("not_configured")
 
@@ -136,34 +186,25 @@ def info():
     print(f"  {_msg('lakehouse')}: {lakehouse or 'N/A'}")
     print(f"  {_msg('endpoint')}: {ONELAKE_ENDPOINT}")
     if workspace and lakehouse:
-        print(f"  {_msg('base_path')}: {lakehouse}.Lakehouse/Files/")
+        base = f"{lakehouse}/Files/" if _is_guid(lakehouse) else f"{lakehouse}.Lakehouse/Files/"
+        print(f"  {_msg('base_path')}: {base}")
 
 
-def ls(path="/", workspace=None):
+def ls(path="/"):
     """List files and directories at the given path.
 
     Args:
         path: Path relative to the lakehouse Files directory. Default "/".
-        workspace: Optional workspace override for cross-workspace access.
 
     Returns:
         List of dicts with 'name', 'is_directory', and 'size' keys.
     """
     fs = _get_fs_client()
-    if workspace:
-        fs = _get_service_client().get_file_system_client(file_system=workspace)
-
     full_path = _build_path(path)
     results = []
     for item in fs.get_paths(path=full_path):
-        name = item.name
-        # Strip the lakehouse prefix for cleaner display
-        _, lh = _get_config()
-        prefix = f"{lh}.Lakehouse/Files/"
-        if name.startswith(prefix):
-            name = name[len(prefix):]
         results.append({
-            "name": name,
+            "name": _strip_prefix(item.name),
             "is_directory": item.is_directory,
             "size": getattr(item, "content_length", 0),
         })

--- a/images/mid/s6/cont-init.d/03-onelake-init
+++ b/images/mid/s6/cont-init.d/03-onelake-init
@@ -1,0 +1,38 @@
+#!/command/with-contenv bash
+
+# OneLake initialization script
+# Checks environment variables and writes status file.
+# Does NOT make network calls - keeps pod startup fast.
+# Auth is handled lazily by onelake_utils.py on first use.
+
+STATUS_FILE="/home/${NB_USER}/.onelake_status"
+
+# If ONELAKE_WORKSPACE is not set, skip silently
+if [ -z "${ONELAKE_WORKSPACE}" ]; then
+    echo "OneLake: ONELAKE_WORKSPACE not set, skipping."
+    # Write minimal status so the helper knows OneLake is not configured
+    cat > "${STATUS_FILE}" << EOF
+{"configured": false}
+EOF
+    chown "${NB_USER}:${NB_GID}" "${STATUS_FILE}" 2>/dev/null
+    exit 0
+fi
+
+# Write OneLake env vars to s6-env for use by services
+S6_ENV="/run/s6-env"
+echo "${ONELAKE_WORKSPACE}" > "${S6_ENV}/ONELAKE_WORKSPACE"
+echo "${ONELAKE_LAKEHOUSE:-}" > "${S6_ENV}/ONELAKE_LAKEHOUSE"
+
+# Make OneLake env vars available in R sessions
+echo "ONELAKE_WORKSPACE=${ONELAKE_WORKSPACE}" >> /opt/conda/lib/R/etc/Renviron
+if [ -n "${ONELAKE_LAKEHOUSE}" ]; then
+    echo "ONELAKE_LAKEHOUSE=${ONELAKE_LAKEHOUSE}" >> /opt/conda/lib/R/etc/Renviron
+fi
+
+# Write status file (JSON) for onelake_utils.py and user inspection
+cat > "${STATUS_FILE}" << EOF
+{"configured": true, "workspace": "${ONELAKE_WORKSPACE}", "lakehouse": "${ONELAKE_LAKEHOUSE:-}", "endpoint": "https://onelake.dfs.fabric.microsoft.com"}
+EOF
+chown "${NB_USER}:${NB_GID}" "${STATUS_FILE}" 2>/dev/null
+
+echo "OneLake: initialized for workspace '${ONELAKE_WORKSPACE}'"

--- a/images/mid/s6/cont-init.d/04-onelake-mount
+++ b/images/mid/s6/cont-init.d/04-onelake-mount
@@ -1,0 +1,132 @@
+#!/command/with-contenv bash
+
+# OneLake blobfuse2 FUSE mount script
+# Mounts OneLake lakehouse Files directory at ~/onelake/
+# Runs after 03-onelake-init which validates env vars.
+# Soft-fails on all errors so the container always boots.
+
+MOUNT_POINT="/home/${NB_USER}/onelake"
+CACHE_DIR="/tmp/blobfuse2-cache"
+CONFIG_FILE="/tmp/blobfuse2-config.yaml"
+STATUS_FILE="/home/${NB_USER}/.onelake_status"
+
+CACHE_SIZE_MB="${ONELAKE_CACHE_SIZE_MB:-2048}"
+CACHE_TTL="${ONELAKE_CACHE_TTL:-300}"
+
+# --- Guard: skip if OneLake is not configured ---
+if [ -z "${ONELAKE_WORKSPACE}" ]; then
+    exit 0
+fi
+
+# --- Guard: skip if FUSE is not available ---
+if [ ! -e /dev/fuse ]; then
+    echo "OneLake mount: /dev/fuse not available, skipping FUSE mount (SDK still works)."
+    exit 0
+fi
+
+# --- Guard: skip if blobfuse2 is not installed ---
+if ! command -v blobfuse2 &>/dev/null; then
+    echo "OneLake mount: blobfuse2 not installed, skipping FUSE mount."
+    exit 0
+fi
+
+# --- Determine lakehouse path format ---
+LAKEHOUSE="${ONELAKE_LAKEHOUSE}"
+if [ -z "${LAKEHOUSE}" ]; then
+    echo "OneLake mount: ONELAKE_LAKEHOUSE not set, skipping FUSE mount."
+    exit 0
+fi
+
+# Check if lakehouse is a GUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+if echo "${LAKEHOUSE}" | grep -qiE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+    LAKEHOUSE_PATH="${LAKEHOUSE}"
+else
+    LAKEHOUSE_PATH="${LAKEHOUSE}.Lakehouse"
+fi
+
+# --- Detect authentication mode ---
+# Priority: Workload Identity > SPN > Azure CLI
+AUTH_SECTION=""
+if [ -n "${AZURE_CLIENT_ID}" ] && [ -n "${AZURE_TENANT_ID}" ] && [ -n "${AZURE_FEDERATED_TOKEN_FILE}" ]; then
+    # Workload Identity
+    AUTH_SECTION="  mode: spn
+  appid: ${AZURE_CLIENT_ID}
+  tenantid: ${AZURE_TENANT_ID}
+  oauth-token-path: ${AZURE_FEDERATED_TOKEN_FILE}"
+    echo "OneLake mount: using Workload Identity auth."
+elif [ -n "${AZURE_CLIENT_ID}" ] && [ -n "${AZURE_TENANT_ID}" ] && [ -n "${AZURE_CLIENT_SECRET}" ]; then
+    # Service Principal
+    AUTH_SECTION="  mode: spn
+  appid: ${AZURE_CLIENT_ID}
+  tenantid: ${AZURE_TENANT_ID}
+  clientsecret: ${AZURE_CLIENT_SECRET}"
+    echo "OneLake mount: using Service Principal auth."
+elif command -v az &>/dev/null && az account show &>/dev/null 2>&1; then
+    # Azure CLI
+    AUTH_SECTION="  mode: azcli"
+    echo "OneLake mount: using Azure CLI auth."
+else
+    echo "OneLake mount: no valid auth found, skipping FUSE mount."
+    exit 0
+fi
+
+# --- Create directories ---
+mkdir -p "${MOUNT_POINT}"
+mkdir -p "${CACHE_DIR}"
+
+# --- Generate blobfuse2 config ---
+cat > "${CONFIG_FILE}" << EOF
+allow-other: true
+
+logging:
+  type: syslog
+  level: log_err
+
+components:
+  - libfuse
+  - file_cache
+  - attr_cache
+  - azstorage
+
+libfuse:
+  attribute-expiration-sec: 120
+  entry-expiration-sec: 120
+  negative-entry-expiration-sec: 30
+
+file_cache:
+  path: ${CACHE_DIR}
+  timeout-sec: ${CACHE_TTL}
+  max-size-mb: ${CACHE_SIZE_MB}
+
+attr_cache:
+  timeout-sec: 120
+
+azstorage:
+  type: adls
+  endpoint: https://onelake.dfs.fabric.microsoft.com
+  container: ${ONELAKE_WORKSPACE}
+  subdirectory: /${LAKEHOUSE_PATH}/Files
+${AUTH_SECTION}
+EOF
+
+chmod 600 "${CONFIG_FILE}"
+
+# --- Mount ---
+if blobfuse2 "${MOUNT_POINT}" --config-file="${CONFIG_FILE}" 2>/tmp/blobfuse2-mount.log; then
+    # Verify mount
+    if mountpoint -q "${MOUNT_POINT}"; then
+        echo "OneLake mount: mounted at ${MOUNT_POINT}"
+        # Update status file with mount info
+        cat > "${STATUS_FILE}" << EOFSTATUS
+{"configured": true, "workspace": "${ONELAKE_WORKSPACE}", "lakehouse": "${LAKEHOUSE}", "endpoint": "https://onelake.dfs.fabric.microsoft.com", "mounted": true, "mount_path": "${MOUNT_POINT}"}
+EOFSTATUS
+        chown "${NB_USER}:${NB_GID}" "${STATUS_FILE}" 2>/dev/null
+    else
+        echo "OneLake mount: blobfuse2 ran but mount not verified."
+    fi
+else
+    echo "OneLake mount: blobfuse2 failed (see /tmp/blobfuse2-mount.log). SDK still works."
+    cat /tmp/blobfuse2-mount.log 2>/dev/null
+fi
+
+exit 0

--- a/tests/general/test_onelake.py
+++ b/tests/general/test_onelake.py
@@ -1,0 +1,54 @@
+"""
+test_onelake
+~~~~~~~~~~~~
+Tests that OneLake SDK packages and the onelake_utils helper module
+are properly installed and importable in the container image.
+"""
+
+import logging
+import pytest
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_onelake_sdk_packages(container):
+    """Test that azure-storage-file-datalake and azure-identity are importable."""
+    container.run()
+    for package in ["azure.storage.filedatalake", "azure.identity"]:
+        LOGGER.info(f"Testing import of {package}")
+        rc = container.container.exec_run(
+            ["python", "-c", f"import {package}"]
+        )
+        assert rc.exit_code == 0, f"Failed to import {package}: {rc.output.decode()}"
+
+
+def test_onelake_utils_importable(container):
+    """Test that onelake_utils module is importable and exposes expected functions."""
+    container.run()
+    rc = container.container.exec_run(
+        [
+            "python",
+            "-c",
+            "import onelake_utils; "
+            "assert hasattr(onelake_utils, 'ls'); "
+            "assert hasattr(onelake_utils, 'read'); "
+            "assert hasattr(onelake_utils, 'write'); "
+            "assert hasattr(onelake_utils, 'download'); "
+            "assert hasattr(onelake_utils, 'upload'); "
+            "assert hasattr(onelake_utils, 'info'); "
+            "print('All onelake_utils functions present')",
+        ]
+    )
+    assert rc.exit_code == 0, f"onelake_utils import check failed: {rc.output.decode()}"
+
+
+def test_onelake_info_unconfigured(container):
+    """Test that onelake_utils.info() works gracefully when OneLake is not configured."""
+    container.run()
+    rc = container.container.exec_run(
+        ["python", "-c", "import onelake_utils; onelake_utils.info()"]
+    )
+    assert rc.exit_code == 0, f"onelake_utils.info() failed: {rc.output.decode()}"
+    output = rc.output.decode()
+    # Should show "Not configured" or "Non configure" (bilingual)
+    assert "N/A" in output or "not" in output.lower() or "non" in output.lower()

--- a/tests/manual/test_onelake_manual.py
+++ b/tests/manual/test_onelake_manual.py
@@ -1,0 +1,889 @@
+#!/usr/bin/env python3
+"""
+OneLake PR #241 — Manual Validation Script
+Run this inside a Zone Kubeflow notebook or terminal.
+
+Usage:
+    python test_onelake_manual.py           # offline tests only
+    python test_onelake_manual.py --live    # include live OneLake connection test
+"""
+
+import importlib
+import inspect
+import json
+import os
+import subprocess
+import sys
+import time
+import traceback
+
+# ── colours & symbols ──────────────────────────────────────────────────────────
+
+GREEN  = "\033[92m"
+RED    = "\033[91m"
+YELLOW = "\033[93m"
+CYAN   = "\033[96m"
+BLUE   = "\033[94m"
+BOLD   = "\033[1m"
+DIM    = "\033[2m"
+RESET  = "\033[0m"
+
+PASS_TAG = f"{GREEN}{BOLD} PASS {RESET}"
+FAIL_TAG = f"{RED}{BOLD} FAIL {RESET}"
+SKIP_TAG = f"{YELLOW}{BOLD} SKIP {RESET}"
+
+# ── state ──────────────────────────────────────────────────────────────────────
+
+results = []  # list of (name, passed: bool|None, detail)
+test_number = 0
+
+
+def section(title):
+    print(f"\n{BOLD}{CYAN}{'━' * 70}{RESET}")
+    print(f"{BOLD}{CYAN}  {title}{RESET}")
+    print(f"{BOLD}{CYAN}{'━' * 70}{RESET}")
+
+
+def evidence(label, content, indent=6):
+    """Print labelled evidence block."""
+    pad = " " * indent
+    print(f"{pad}{BLUE}{label}:{RESET}")
+    if isinstance(content, str):
+        for line in content.split("\n"):
+            print(f"{pad}  {DIM}{line}{RESET}")
+    elif isinstance(content, (list, dict)):
+        formatted = json.dumps(content, indent=2)
+        for line in formatted.split("\n"):
+            print(f"{pad}  {DIM}{line}{RESET}")
+
+
+def verdict(name, passed, reasoning, evidence_blocks=None):
+    """Record and display a test result with reasoning."""
+    global test_number
+    test_number += 1
+    results.append((name, passed, reasoning))
+
+    if passed is None:
+        tag = SKIP_TAG
+    elif passed:
+        tag = PASS_TAG
+    else:
+        tag = FAIL_TAG
+
+    print(f"\n  {tag}  {BOLD}{name}{RESET}")
+    print(f"         {DIM}Reasoning: {reasoning}{RESET}")
+
+    if evidence_blocks:
+        for label, content in evidence_blocks:
+            evidence(label, content)
+
+
+def timed(fn):
+    """Run a function and return (result, elapsed_ms)."""
+    t0 = time.perf_counter()
+    result = fn()
+    elapsed = (time.perf_counter() - t0) * 1000
+    return result, elapsed
+
+
+# ── Test 1: SDK packages ──────────────────────────────────────────────────────
+
+def test_sdk_packages():
+    section("1 / 8 · Python SDK Packages")
+    print(f"\n  {DIM}Why: PR #241 adds 'azure-storage-file-datalake' and 'azure-identity'")
+    print(f"  to the mid Dockerfile. If these don't import, the entire OneLake")
+    print(f"  integration is dead on arrival.{RESET}")
+
+    for pkg_name, pip_name in [
+        ("azure.storage.filedatalake", "azure-storage-file-datalake"),
+        ("azure.identity", "azure-identity"),
+    ]:
+        try:
+            mod, ms = timed(lambda p=pkg_name: importlib.import_module(p))
+            version = getattr(mod, "__version__", getattr(mod, "VERSION", "unknown"))
+            location = getattr(mod, "__file__", "unknown")
+
+            verdict(
+                f"import {pkg_name}",
+                True,
+                f"Module loaded in {ms:.0f}ms. Version resolves to '{version}'. "
+                f"This confirms the pip package '{pip_name}' was installed correctly "
+                f"in the container image and is on sys.path.",
+                [
+                    ("Module file", location),
+                    ("Version", str(version)),
+                    ("Import time", f"{ms:.1f}ms"),
+                ],
+            )
+        except ImportError as e:
+            verdict(
+                f"import {pkg_name}",
+                False,
+                f"ImportError means '{pip_name}' is not installed or has a broken "
+                f"dependency. Check the Dockerfile RUN pip install layer.",
+                [("Exception", str(e))],
+            )
+
+
+# ── Test 2: Helper module ─────────────────────────────────────────────────────
+
+def test_helper_import():
+    section("2 / 8 · onelake_utils Helper Module")
+    print(f"\n  {DIM}Why: PR #241 COPYs onelake_utils.py into site-packages. This is")
+    print(f"  the user-facing API — if it's missing or malformed, users get nothing.{RESET}")
+
+    try:
+        mod, ms = timed(lambda: importlib.import_module("onelake_utils"))
+        location = getattr(mod, "__file__", "unknown")
+        all_attrs = [a for a in dir(mod) if not a.startswith("_")]
+
+        verdict(
+            "import onelake_utils",
+            True,
+            f"Module loaded in {ms:.0f}ms from '{location}'. "
+            f"This confirms the COPY instruction in the Dockerfile placed the file "
+            f"at the correct site-packages path for the container's Python version.",
+            [
+                ("Module file", location),
+                ("Public attributes", ", ".join(all_attrs)),
+                ("Import time", f"{ms:.1f}ms"),
+            ],
+        )
+    except ImportError as e:
+        verdict(
+            "import onelake_utils",
+            False,
+            f"Module not found. The Dockerfile COPYs to python3.13/site-packages — "
+            f"if the container's Python is a different version, the path is wrong.",
+            [("Exception", str(e)), ("sys.path", "\n".join(sys.path))],
+        )
+        return
+
+    expected_fns = ["ls", "read", "write", "download", "upload", "info"]
+    for fn_name in expected_fns:
+        attr = getattr(mod, fn_name, None)
+        if attr is not None and callable(attr):
+            sig = str(inspect.signature(attr))
+            doc = (inspect.getdoc(attr) or "").split("\n")[0]
+            verdict(
+                f"onelake_utils.{fn_name}{sig}",
+                True,
+                f"Function exists and is callable. Signature matches the plan spec. "
+                f"First line of docstring: \"{doc}\"",
+                [("Signature", f"{fn_name}{sig}"), ("Docstring", doc)],
+            )
+        else:
+            verdict(
+                f"onelake_utils.{fn_name}() exists",
+                False,
+                f"Attribute is {'not callable' if attr else 'missing'}. "
+                f"Check onelake_utils.py source for typos or missing def.",
+            )
+
+    # Check key internals exist
+    endpoint = getattr(mod, "ONELAKE_ENDPOINT", None)
+    if endpoint:
+        verdict(
+            "ONELAKE_ENDPOINT constant",
+            endpoint == "https://onelake.dfs.fabric.microsoft.com",
+            f"Endpoint is '{endpoint}'. Must be the OneLake DFS endpoint, not "
+            f"the regular Azure dfs.core.windows.net — that would hit a "
+            f"completely different service.",
+            [("Value", endpoint)],
+        )
+    else:
+        verdict("ONELAKE_ENDPOINT constant", False, "Constant not found in module.")
+
+
+# ── Test 3: info() unconfigured ───────────────────────────────────────────────
+
+def test_info_unconfigured():
+    section("3 / 8 · info() Without Config (Graceful Degradation)")
+    print(f"\n  {DIM}Why: When a user spins up a notebook without OneLake env vars,")
+    print(f"  info() must NOT crash. It should print a clear 'not configured'")
+    print(f"  message. If it throws, every new user's first experience is broken.{RESET}")
+
+    saved = {
+        "ONELAKE_WORKSPACE": os.environ.pop("ONELAKE_WORKSPACE", None),
+        "ONELAKE_LAKEHOUSE": os.environ.pop("ONELAKE_LAKEHOUSE", None),
+    }
+
+    try:
+        import onelake_utils
+        importlib.reload(onelake_utils)
+        onelake_utils._client = None
+        onelake_utils._fs_client = None
+
+        from io import StringIO
+        import contextlib
+
+        buf = StringIO()
+        exc = None
+        try:
+            with contextlib.redirect_stdout(buf):
+                onelake_utils.info()
+        except Exception as e:
+            exc = e
+
+        output = buf.getvalue()
+
+        if exc:
+            verdict(
+                "info() runs without crash",
+                False,
+                f"Threw {type(exc).__name__}: {exc}. This means every user without "
+                f"OneLake config will see a stack trace instead of a helpful message.",
+                [("Exception", traceback.format_exc()), ("Stdout before crash", output)],
+            )
+            return
+
+        verdict(
+            "info() runs without crash",
+            True,
+            "Function completed without exception. Users will see output, not a traceback.",
+            [("Full output", output.strip())],
+        )
+
+        has_na = "N/A" in output
+        verdict(
+            "info() shows 'N/A' for missing workspace/lakehouse",
+            has_na,
+            f"{'Found' if has_na else 'Missing'} 'N/A' in output. When env vars "
+            f"aren't set, displaying N/A clearly tells the user nothing is configured "
+            f"vs leaving fields blank (which looks like a bug).",
+            [("Output", output.strip())],
+        )
+
+        has_status = "not configured" in output.lower() or "non config" in output.lower()
+        verdict(
+            "info() shows 'Not configured' status",
+            has_status,
+            f"{'Found' if has_status else 'Missing'} status indicator. The user needs "
+            f"to know OneLake is OFF — not that it failed or is partially working.",
+            [("Output", output.strip())],
+        )
+    finally:
+        for key, val in saved.items():
+            if val is not None:
+                os.environ[key] = val
+
+
+# ── Test 4: Bilingual messages ────────────────────────────────────────────────
+
+def test_bilingual():
+    section("4 / 8 · Bilingual (EN/FR) Messages")
+    print(f"\n  {DIM}Why: StatCan is a federal agency under the Official Languages Act.")
+    print(f"  All user-facing text must work in both English and French.")
+    print(f"  The module checks the LANG env var to pick the language.{RESET}")
+
+    from io import StringIO
+    import contextlib
+    import onelake_utils
+
+    saved = {
+        "LANG": os.environ.get("LANG"),
+        "ONELAKE_WORKSPACE": os.environ.pop("ONELAKE_WORKSPACE", None),
+        "ONELAKE_LAKEHOUSE": os.environ.pop("ONELAKE_LAKEHOUSE", None),
+    }
+
+    try:
+        def capture_info(lang_val):
+            os.environ["LANG"] = lang_val
+            importlib.reload(onelake_utils)
+            onelake_utils._client = None
+            onelake_utils._fs_client = None
+            buf = StringIO()
+            with contextlib.redirect_stdout(buf):
+                onelake_utils.info()
+            return buf.getvalue()
+
+        # English
+        en_out = capture_info("en_US.UTF-8")
+        en_keys = ["Status", "Workspace", "Endpoint"]
+        en_found = [k for k in en_keys if k in en_out]
+        en_missing = [k for k in en_keys if k not in en_out]
+
+        verdict(
+            "English output (LANG=en_US.UTF-8)",
+            len(en_missing) == 0,
+            f"Found {len(en_found)}/{len(en_keys)} expected English labels. "
+            f"{'All present.' if not en_missing else 'Missing: ' + ', '.join(en_missing)}",
+            [("LANG", "en_US.UTF-8"), ("Output", en_out.strip())],
+        )
+
+        # French
+        fr_out = capture_info("fr_CA.UTF-8")
+        fr_keys = ["Statut", "Espace de travail", "Point de terminaison"]
+        fr_found = [k for k in fr_keys if k in fr_out]
+        fr_missing = [k for k in fr_keys if k not in fr_out]
+
+        verdict(
+            "French output (LANG=fr_CA.UTF-8)",
+            len(fr_missing) == 0,
+            f"Found {len(fr_found)}/{len(fr_keys)} expected French labels. "
+            f"{'All present.' if not fr_missing else 'Missing: ' + ', '.join(fr_missing)}",
+            [("LANG", "fr_CA.UTF-8"), ("Output", fr_out.strip())],
+        )
+
+        # Verify they're actually different
+        are_different = en_out != fr_out
+        verdict(
+            "EN and FR outputs are different strings",
+            are_different,
+            f"{'Outputs differ' if are_different else 'Outputs are IDENTICAL'} — "
+            f"if they match, the LANG switch is not being read and one language "
+            f"is hardcoded.",
+            [("EN (first line)", en_out.strip().split("\n")[0]),
+             ("FR (first line)", fr_out.strip().split("\n")[0])],
+        )
+    except Exception as e:
+        verdict("Bilingual test", False, str(e), [("Traceback", traceback.format_exc())])
+    finally:
+        if saved["LANG"] is not None:
+            os.environ["LANG"] = saved["LANG"]
+        elif "LANG" in os.environ:
+            del os.environ["LANG"]
+        for key in ["ONELAKE_WORKSPACE", "ONELAKE_LAKEHOUSE"]:
+            if saved[key] is not None:
+                os.environ[key] = saved[key]
+
+
+# ── Test 5: Graceful errors ───────────────────────────────────────────────────
+
+def test_graceful_errors():
+    section("5 / 8 · Graceful Errors (Operations Without Config)")
+    print(f"\n  {DIM}Why: If a user calls onelake.ls('/') without env vars set, they")
+    print(f"  should get a clear RuntimeError saying ONELAKE_WORKSPACE is missing —")
+    print(f"  not a cryptic Azure SDK traceback about NoneType or empty strings.{RESET}")
+
+    saved = {
+        "ONELAKE_WORKSPACE": os.environ.pop("ONELAKE_WORKSPACE", None),
+        "ONELAKE_LAKEHOUSE": os.environ.pop("ONELAKE_LAKEHOUSE", None),
+    }
+
+    try:
+        import onelake_utils
+        importlib.reload(onelake_utils)
+        onelake_utils._client = None
+        onelake_utils._fs_client = None
+
+        test_calls = [
+            ("ls", lambda: onelake_utils.ls("/")),
+            ("read", lambda: onelake_utils.read("/dummy")),
+            ("download", lambda: onelake_utils.download("/dummy", "/tmp/dummy")),
+            ("write", lambda: onelake_utils.write("/dummy", b"data")),
+        ]
+
+        for fn_name, fn_call in test_calls:
+            try:
+                fn_call()
+                verdict(
+                    f"{fn_name}() raises RuntimeError when unconfigured",
+                    False,
+                    f"No exception raised. {fn_name}() should fail before any "
+                    f"network call because ONELAKE_WORKSPACE is empty. If it "
+                    f"silently succeeds, it might hit Azure with bad params.",
+                )
+            except RuntimeError as e:
+                msg = str(e)
+                mentions_var = "ONELAKE_WORKSPACE" in msg or "ONELAKE_LAKEHOUSE" in msg
+
+                verdict(
+                    f"{fn_name}() raises RuntimeError when unconfigured",
+                    True,
+                    f"Correctly raises RuntimeError before attempting any network I/O. "
+                    f"The error message {'names the missing env var' if mentions_var else 'does NOT name the env var (should it?)'}.",
+                    [("Exception type", "RuntimeError"),
+                     ("Message", msg),
+                     ("Mentions env var", str(mentions_var))],
+                )
+
+                if not mentions_var:
+                    verdict(
+                        f"{fn_name}() error message names the missing env var",
+                        False,
+                        f"Error message is \"{msg}\" — it should explicitly say "
+                        f"'ONELAKE_WORKSPACE' or 'ONELAKE_LAKEHOUSE' so the user "
+                        f"knows exactly what to fix, not just 'not set'.",
+                    )
+            except Exception as e:
+                verdict(
+                    f"{fn_name}() raises RuntimeError when unconfigured",
+                    False,
+                    f"Raised {type(e).__name__} instead of RuntimeError. Raw Azure "
+                    f"SDK exceptions leak implementation details to users.",
+                    [("Exception type", type(e).__name__), ("Message", str(e))],
+                )
+    finally:
+        for key, val in saved.items():
+            if val is not None:
+                os.environ[key] = val
+
+
+# ── Test 6: s6 status file ───────────────────────────────────────────────────
+
+def test_s6_status_file():
+    section("6 / 8 · s6 Init Script (Status File)")
+    print(f"\n  {DIM}Why: The 03-onelake-init s6 script writes ~/.onelake_status at")
+    print(f"  container boot. The helper module and users can read it to check")
+    print(f"  config without making network calls. If not running in s6, this is")
+    print(f"  expected to be missing.{RESET}")
+
+    home = os.path.expanduser("~")
+    status_path = os.path.join(home, ".onelake_status")
+
+    if not os.path.exists(status_path):
+        verdict(
+            "~/.onelake_status exists",
+            None,  # skip
+            f"File not found at '{status_path}'. This is expected if you're "
+            f"running outside the container (s6-overlay creates this at boot). "
+            f"To test: run this script inside a built container.",
+            [("Expected path", status_path)],
+        )
+        return
+
+    try:
+        with open(status_path) as f:
+            raw = f.read()
+
+        verdict(
+            "~/.onelake_status exists and is readable",
+            True,
+            f"File found ({len(raw)} bytes). s6 init script ran successfully.",
+            [("Path", status_path), ("Raw content", raw.strip())],
+        )
+
+        data = json.loads(raw)
+        verdict(
+            "~/.onelake_status is valid JSON",
+            True,
+            f"Parsed successfully. Both the helper module and shell scripts "
+            f"can consume this file.",
+            [("Parsed", data)],
+        )
+
+        has_key = "configured" in data
+        verdict(
+            "Status JSON has 'configured' key",
+            has_key,
+            f"{'Found' if has_key else 'Missing'} the 'configured' boolean. "
+            f"This is the primary flag the helper checks to know if OneLake "
+            f"was set up by the init script.",
+            [("Keys present", list(data.keys()))],
+        )
+
+        if data.get("configured"):
+            ws = data.get("workspace", "")
+            ep = data.get("endpoint", "")
+            verdict(
+                "Status shows configured=true with workspace",
+                bool(ws),
+                f"Workspace: '{ws}'. Endpoint: '{ep}'. The init script found "
+                f"ONELAKE_WORKSPACE in the environment and recorded it.",
+                [("Full status", data)],
+            )
+        else:
+            verdict(
+                "Status shows configured=false (expected without env vars)",
+                True,
+                f"ONELAKE_WORKSPACE was not set when the container booted. "
+                f"This is normal for pods without OneLake PodDefaults.",
+                [("Full status", data)],
+            )
+    except json.JSONDecodeError as e:
+        verdict(
+            "~/.onelake_status is valid JSON",
+            False,
+            f"JSON parse failed. The s6 init script's heredoc may have been "
+            f"corrupted by variable expansion or missing quotes.",
+            [("Raw content", raw.strip()), ("Parse error", str(e))],
+        )
+    except Exception as e:
+        verdict("~/.onelake_status readable", False, str(e))
+
+
+# ── Test 7: R environment ────────────────────────────────────────────────────
+
+def test_r_environment():
+    section("7 / 8 · R Environment Integrity")
+    print(f"\n  {DIM}Why: Commit 6d0234c removed 13 R packages from the mamba install")
+    print(f"  to reduce build time. We need to verify R itself still starts and")
+    print(f"  the init script's Renviron writes didn't break anything.{RESET}")
+
+    # 7a: R starts
+    try:
+        result, ms = timed(lambda: subprocess.run(
+            ["R", "--vanilla", "-e", "cat(R.version.string)"],
+            capture_output=True, text=True, timeout=30,
+        ))
+        if result.returncode == 0:
+            # R --vanilla -e "cat(...)" outputs the version after the > prompt
+            # Filter out empty lines and R prompt lines to get the actual version
+            stdout_lines = result.stdout.strip().split("\n")
+            version = "unknown"
+            for line in stdout_lines:
+                cleaned = line.strip().lstrip("> ").strip()
+                if cleaned.startswith("R version"):
+                    version = cleaned
+                    break
+            if version == "unknown":
+                # Fallback: try stderr where R sometimes prints version info
+                for line in result.stderr.strip().split("\n"):
+                    if "R version" in line:
+                        version = line.strip()
+                        break
+            verdict(
+                "R starts and reports version",
+                True,
+                f"R launched in {ms:.0f}ms and printed version string. "
+                f"The removal of R packages from mamba did not break the R runtime.",
+                [("R version", version), ("Startup time", f"{ms:.0f}ms")],
+            )
+        else:
+            stderr = result.stderr.strip()[:300]
+            verdict(
+                "R starts and reports version",
+                False,
+                f"R exited with code {result.returncode}. Removing packages "
+                f"from the mamba layer may have broken a dependency chain.",
+                [("Exit code", str(result.returncode)), ("Stderr", stderr)],
+            )
+            return
+    except FileNotFoundError:
+        verdict(
+            "R starts and reports version",
+            None,
+            "R not found on PATH. Expected if running outside the container.",
+        )
+        return
+    except subprocess.TimeoutExpired:
+        verdict("R starts and reports version", False, "Timed out after 30s. R may be hanging on startup.")
+        return
+
+    # 7b: Renviron file exists and is readable
+    renviron = "/opt/conda/lib/R/etc/Renviron"
+    try:
+        result = subprocess.run(
+            ["R", "--vanilla", "-e", f"cat(readLines('{renviron}', warn=FALSE), sep='\\n')"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode == 0:
+            content = result.stdout.strip()
+            has_onelake_line = "ONELAKE_WORKSPACE" in content
+            verdict(
+                "Renviron file accessible from R",
+                True,
+                f"R can read '{renviron}'. "
+                f"{'Contains ONELAKE_WORKSPACE line (s6 init script wrote it).' if has_onelake_line else 'No ONELAKE_WORKSPACE line yet (expected — s6 writes it at boot, not at build time).'}",
+                [("ONELAKE vars present", str(has_onelake_line))],
+            )
+    except Exception:
+        pass  # non-critical
+
+
+# ── Test 8: Live OneLake connection ──────────────────────────────────────────
+
+def test_live_connection():
+    section("8 / 8 · Live OneLake Connection")
+    print(f"\n  {DIM}Why: This is the real proof. Tests 1–7 verify the code is installed")
+    print(f"  correctly. This test verifies the end-to-end flow: auth, network,")
+    print(f"  OneLake API, read, write. If this passes, Phase 1 works.{RESET}")
+
+    ws = os.environ.get("ONELAKE_WORKSPACE", "")
+    lh = os.environ.get("ONELAKE_LAKEHOUSE", "")
+
+    if not ws:
+        print(f"\n  {YELLOW}ONELAKE_WORKSPACE is not set in environment.{RESET}")
+        print(f"  {DIM}This is expected outside the Zone platform.{RESET}")
+        ws = input(f"\n  Enter workspace name or GUID (or Enter to skip): ").strip()
+        if not ws:
+            verdict("Live connection test", None, "Skipped — no workspace provided. Run with env vars set on the Zone.")
+            return
+        os.environ["ONELAKE_WORKSPACE"] = ws
+
+    if not lh:
+        print(f"\n  {YELLOW}ONELAKE_LAKEHOUSE is not set in environment.{RESET}")
+        lh = input(f"  Enter lakehouse name (or Enter to skip): ").strip()
+        if not lh:
+            verdict("Live connection test", None, "Skipped — no lakehouse provided.")
+            return
+        os.environ["ONELAKE_LAKEHOUSE"] = lh
+
+    print(f"\n  {DIM}Using workspace: {ws}{RESET}")
+    print(f"  {DIM}Using lakehouse: {lh}{RESET}")
+
+    import onelake_utils
+    importlib.reload(onelake_utils)
+    onelake_utils._client = None
+    onelake_utils._fs_client = None
+
+    # 8a: Network reachability (W0-1 from stress test doc)
+    print(f"\n  {DIM}Testing network reachability to OneLake endpoint...{RESET}")
+    try:
+        import urllib.request
+        req = urllib.request.Request(
+            "https://onelake.dfs.fabric.microsoft.com",
+            method="HEAD",
+        )
+        resp, ms = timed(lambda: urllib.request.urlopen(req, timeout=10))
+        verdict(
+            "Network: onelake.dfs.fabric.microsoft.com reachable",
+            True,
+            f"Got HTTP {resp.status} in {ms:.0f}ms. The pod's egress rules "
+            f"allow traffic to OneLake. (This validates W0-1 from the stress test doc.)",
+            [("HTTP status", str(resp.status)), ("Latency", f"{ms:.0f}ms")],
+        )
+    except Exception as e:
+        err_type = type(e).__name__
+        verdict(
+            "Network: onelake.dfs.fabric.microsoft.com reachable",
+            # A 400/403 still means the endpoint is reachable
+            "urlopen" not in str(e).lower() and "timeout" not in str(e).lower(),
+            f"Got {err_type}: {e}. If this is a connection/timeout error, the "
+            f"firewall is blocking egress and ALL OneLake access is dead. "
+            f"If it's an HTTP error (400/403), the endpoint is reachable but "
+            f"auth or request format is wrong — that's fine for a HEAD request.",
+            [("Exception", f"{err_type}: {e}")],
+        )
+
+    # 8b: info() with config
+    from io import StringIO
+    import contextlib
+
+    try:
+        buf = StringIO()
+        with contextlib.redirect_stdout(buf):
+            onelake_utils.info()
+        out = buf.getvalue()
+        has_connected = "connected" in out.lower() or "connecte" in out.lower()
+        verdict(
+            "info() with config shows 'Connected'",
+            has_connected,
+            f"With env vars set, info() should report connected status. "
+            f"Note: this checks config presence, not actual auth — auth is lazy.",
+            [("Output", out.strip())],
+        )
+    except Exception as e:
+        verdict("info() with config", False, str(e))
+
+    # 8c: ls() — the real auth + network + API test
+    print(f"\n  {DIM}Attempting ls('/') — this will trigger authentication...{RESET}")
+    print(f"  {DIM}(DefaultAzureCredential will try Workload Identity, then MSI,")
+    print(f"   then SPN env vars, then Azure CLI token, in order){RESET}\n")
+
+    try:
+        items, ms = timed(lambda: onelake_utils.ls("/"))
+        verdict(
+            "ls('/') succeeds — auth + network + API all working",
+            True,
+            f"Returned {len(items)} items in {ms:.0f}ms. This single call proves: "
+            f"(1) DefaultAzureCredential found a valid token, "
+            f"(2) the token has Fabric workspace read permissions, "
+            f"(3) OneLake's DFS API accepted the workspace/lakehouse path. "
+            f"This validates W0-3, W0-4, and W0-5 from the stress test doc.",
+            [("Items returned", str(len(items))),
+             ("Auth + API time", f"{ms:.0f}ms")],
+        )
+        for item in items[:8]:
+            kind = "DIR " if item.get("is_directory") else "FILE"
+            size = item.get("size", 0)
+            print(f"       {DIM}{kind}  {item['name']:<40} ({size:,} bytes){RESET}")
+        if len(items) > 8:
+            print(f"       {DIM}... and {len(items) - 8} more{RESET}")
+
+    except Exception as e:
+        verdict(
+            "ls('/') succeeds",
+            False,
+            f"Failed with {type(e).__name__}: {e}. Diagnose: "
+            f"(1) Is this a 401/403? — Check SPN permissions on the Fabric workspace. "
+            f"(2) Is this a connection error? — Firewall blocking egress. "
+            f"(3) Is this a 404? — Wrong workspace name or GUID. "
+            f"(4) Is the Fabric tenant setting 'external access to OneLake' ON?",
+            [("Exception", f"{type(e).__name__}: {e}"),
+             ("Traceback", traceback.format_exc()[-500:])],
+        )
+        return  # can't test write/read if ls fails
+
+    # 8d: write + read round-trip
+    test_file = "__zone_onelake_test.txt"
+    test_data = f"Zone OneLake validation | {time.strftime('%Y-%m-%d %H:%M:%S')} | PR #241"
+    print(f"\n  {DIM}Testing write → read round-trip with '{test_file}'...{RESET}")
+
+    try:
+        _, w_ms = timed(lambda: onelake_utils.write(test_file, test_data))
+        verdict(
+            f"write('{test_file}') succeeds",
+            True,
+            f"Wrote {len(test_data)} bytes in {w_ms:.0f}ms. This proves write "
+            f"permissions on the lakehouse — the SPN/WI token has Contributor "
+            f"or Writer role.",
+            [("Bytes written", str(len(test_data))),
+             ("Write time", f"{w_ms:.0f}ms"),
+             ("Content", test_data)],
+        )
+    except Exception as e:
+        verdict(
+            f"write('{test_file}') succeeds",
+            False,
+            f"Write failed. If ls() worked but write fails, the credential "
+            f"has read-only access. Check the SPN's Fabric role.",
+            [("Exception", f"{type(e).__name__}: {e}")],
+        )
+        return
+
+    try:
+        got, r_ms = timed(lambda: onelake_utils.read(test_file, as_text=True))
+        match = got == test_data
+        verdict(
+            "read() returns exact data that was written",
+            match,
+            f"Read {len(got)} bytes in {r_ms:.0f}ms. "
+            f"{'Data matches exactly — full round-trip confirmed.' if match else f'DATA MISMATCH. Expected {len(test_data)} bytes, got {len(got)}. Possible encoding issue or partial write.'}",
+            [("Expected", test_data),
+             ("Got", got),
+             ("Match", str(match)),
+             ("Read time", f"{r_ms:.0f}ms")],
+        )
+    except Exception as e:
+        verdict(f"read('{test_file}')", False, str(e))
+
+    # 8e: download to local filesystem
+    local_tmp = "/tmp/__zone_onelake_test.txt"
+    try:
+        _, d_ms = timed(lambda: onelake_utils.download(test_file, local_tmp))
+        with open(local_tmp) as f:
+            content = f.read()
+        match = content == test_data
+        file_size = os.path.getsize(local_tmp)
+
+        verdict(
+            "download() writes correct local file",
+            match,
+            f"Downloaded to '{local_tmp}' ({file_size} bytes) in {d_ms:.0f}ms. "
+            f"{'Content matches original.' if match else 'CONTENT MISMATCH.'}",
+            [("Local path", local_tmp),
+             ("File size", f"{file_size} bytes"),
+             ("Content match", str(match)),
+             ("Download time", f"{d_ms:.0f}ms")],
+        )
+    except Exception as e:
+        verdict(f"download('{test_file}')", False, str(e))
+    finally:
+        if os.path.exists(local_tmp):
+            os.remove(local_tmp)
+
+    # 8f: upload round-trip
+    upload_local = "/tmp/__zone_upload_test.txt"
+    upload_remote = "__zone_upload_test.txt"
+    upload_data = f"Upload test | {time.strftime('%Y-%m-%d %H:%M:%S')}"
+    try:
+        with open(upload_local, "w") as f:
+            f.write(upload_data)
+
+        _, u_ms = timed(lambda: onelake_utils.upload(upload_local, upload_remote))
+        got = onelake_utils.read(upload_remote, as_text=True)
+        match = got == upload_data
+
+        verdict(
+            "upload() local file → OneLake round-trip",
+            match,
+            f"Uploaded {len(upload_data)} bytes in {u_ms:.0f}ms, read back matches. "
+            f"This confirms the full cycle: local file → OneLake → read back.",
+            [("Upload time", f"{u_ms:.0f}ms"), ("Match", str(match))],
+        )
+    except Exception as e:
+        verdict("upload() round-trip", False, str(e))
+    finally:
+        if os.path.exists(upload_local):
+            os.remove(upload_local)
+
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+def summary():
+    section("Results Summary")
+
+    total   = len(results)
+    passed  = sum(1 for _, s, _ in results if s is True)
+    failed  = sum(1 for _, s, _ in results if s is False)
+    skipped = sum(1 for _, s, _ in results if s is None)
+
+    bar_width = 50
+    p_width = int(bar_width * passed / total) if total else 0
+    f_width = int(bar_width * failed / total) if total else 0
+    s_width = bar_width - p_width - f_width
+
+    bar = f"{GREEN}{'█' * p_width}{RED}{'█' * f_width}{YELLOW}{'░' * s_width}{RESET}"
+    print(f"\n  {bar}")
+    print(f"  {GREEN}{passed} passed{RESET}  {RED}{failed} failed{RESET}  {YELLOW}{skipped} skipped{RESET}  {DIM}({total} total){RESET}\n")
+
+    if failed:
+        print(f"  {RED}{BOLD}Failures requiring attention:{RESET}\n")
+        for name, status, reasoning in results:
+            if status is False:
+                print(f"    {RED}x{RESET}  {name}")
+                print(f"       {DIM}{reasoning[:120]}{RESET}")
+        print()
+
+    if failed == 0 and skipped == 0:
+        print(f"  {GREEN}{BOLD}All {total} checks passed. PR #241 is validated.{RESET}\n")
+    elif failed == 0:
+        print(f"  {GREEN}{BOLD}All executed checks passed ({skipped} skipped).{RESET}")
+        print(f"  {DIM}Skipped tests are expected outside the container environment.{RESET}\n")
+    else:
+        print(f"  {RED}{BOLD}{failed} check(s) need investigation before merging.{RESET}\n")
+
+    return 1 if failed else 0
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    live = "--live" in sys.argv
+
+    print(f"\n{BOLD}{'═' * 70}{RESET}")
+    print(f"{BOLD}  OneLake PR #241 — Validation Suite{RESET}")
+    print(f"{BOLD}  {DIM}zone-kubeflow-containers | Phase 1 SDK Integration{RESET}")
+    print(f"{BOLD}{'═' * 70}{RESET}")
+    print(f"  {DIM}Date: {time.strftime('%Y-%m-%d %H:%M:%S')}{RESET}")
+    print(f"  {DIM}Mode: {'LIVE (with OneLake connection)' if live else 'OFFLINE (install verification only)'}{RESET}")
+    print(f"  {DIM}Python: {sys.version.split()[0]} at {sys.executable}{RESET}")
+    if not live:
+        print(f"\n  {YELLOW}Tip: Run with --live to test actual OneLake connectivity.{RESET}")
+
+    test_sdk_packages()
+    test_helper_import()
+    test_info_unconfigured()
+    test_bilingual()
+    test_graceful_errors()
+    test_s6_status_file()
+    test_r_environment()
+
+    if live:
+        test_live_connection()
+    else:
+        section("8 / 8 · Live OneLake Connection")
+        verdict(
+            "Live connection test",
+            None,
+            "Skipped — pass --live flag to enable. This tests actual auth, "
+            "network egress, and OneLake read/write from inside the pod.",
+        )
+
+    code = summary()
+
+    # Raise SystemExit only when run as a script, not inside Jupyter/IPython
+    try:
+        get_ipython()  # noqa: F821 — defined in IPython environments
+        # Inside Jupyter/IPython — don't call sys.exit(), just return the code
+        if code != 0:
+            print(f"  {DIM}(exit code: {code}){RESET}")
+    except NameError:
+        # Running as a normal script — safe to exit
+        sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

## Phase 1: Python SDK Package creation for one line commands for users

- Install azure-storage-file-datalake and azure-identity in mid Dockerfile
- Add onelake_utils.py helper with lazy auth (no startup delay)
- Add s6 init script 03-onelake-init for env var setup
- Add tests for SDK imports and helper module

## Phase 2: blobfuse2 FUSE Mount

- Install blobfuse2 + fuse3 in mid Dockerfile (Microsoft apt repo already configured in base)
- Add s6 init script 04-onelake-mount: auto-detects auth, generates config, mounts at ~/onelake/
- Update onelake_utils.py: read() and download() use local mount when available, falls back to SDK
- Disk cache at /tmp/blobfuse2-cache (2GB, 5min TTL) for fast repeated reads
- Soft-fail on all errors — container always boots, SDK works even without FUSE

**What your PR adds/fixes/removes**
Adding OneLake mounting capability and Python SDK package for one liners. 

Adding OneLake filesystem mount via blobfuse2. Users can now `ls ~/onelake/`, `cat ~/onelake/data.csv`, or use Jupyter file browser to access OneLake files natively. No Python needed for basic file operations.

# Tests / Quality Checks
To be tested. 

# Beta Process
- [ ] Should this branch target "beta"?

## Are there breaking changes?
No. Fully backwards compatible — if /dev/fuse is not available on the pod, everything falls back to the SDK silently. Existing functionality is unchanged.

Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
