### PR TITLE
feat: remove old R extensions, add Air and remove Quarto extension

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -40,9 +40,8 @@ RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     # Manage extensions
     code-server --install-extension ms-python.python@2025.4.0 && \
     code-server --install-extension ms-python.debugpy@2025.4.0 && \
-    code-server --install-extension REditorSupport.r@2.8.4 && \
+    code-server --install-extension Posit.air-vscode@0.22.0 && \
     code-server --install-extension ms-ceintl.vscode-language-pack-fr@1.99.0 && \
-    code-server --install-extension quarto.quarto@1.113.0 && \
     code-server --install-extension adamviola.parquet-explorer@1.2.1 && \
     code-server --install-extension redhat.vscode-yaml@1.15.0 && \
     code-server --install-extension ms-vscode.azurecli@0.6.0 && \


### PR DESCRIPTION
- I've added Air since I wasn't able to install from the marketplace.
- Removed R because it's replaced by Air
- Remove Quarto since I was able to install the extension from the marketplace.

- JIRA: https://jirab.statcan.ca/browse/ZONE-359