### PR TITLE
feat: ensure conda Python is used

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -97,6 +97,10 @@ COPY --chmod=755 suspend-server.sh adjust-server-resources.py ktutil-keytab /usr
 # add clean-layer script
 COPY --chmod=755 clean-layer.sh /usr/bin/clean-layer.sh
 
+# Set conda Python as the default for user sessions
+COPY --chmod=755 set-python-default.sh /usr/local/bin/set-python-default.sh
+RUN /usr/local/bin/set-python-default.sh
+
 # Combined tool installations with cleanup
 RUN \
     # S6 Overlay

--- a/images/base/set-python-default.sh
+++ b/images/base/set-python-default.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Set conda Python as the default system Python
+# This ensures /opt/conda/bin/python is selected over /usr/bin/python3
+
+set -e
+
+CONDA_PYTHON="/opt/conda/bin/python3"
+
+# Check if conda python exists
+if [ ! -f "$CONDA_PYTHON" ]; then
+    echo "Warning: Conda Python not found at $CONDA_PYTHON"
+    exit 0
+fi
+
+# Method 1: Update /etc/environment to prioritize conda in PATH
+# This affects all sessions system-wide
+if ! grep -q "/opt/conda/bin" /etc/environment 2>/dev/null; then
+    # Remove any existing PATH line and add new one with conda first
+    if grep -q "^PATH=" /etc/environment; then
+        sed -i 's|^PATH=.*|PATH="/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"|' /etc/environment
+    else
+        echo 'PATH="/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' >> /etc/environment
+    fi
+    echo "Updated /etc/environment to prioritize conda Python"
+fi
+
+# NOTE: We do NOT use update-alternatives for python3 to avoid breaking
+# system tools like add-apt-repository that require the system Python.
+# PATH-based switching (Methods 1 and 3) is sufficient for user sessions.
+
+# Method 3: Ensure /etc/profile.d script for shell sessions
+cat > /etc/profile.d/conda-python.sh << 'EOF'
+# Prioritize conda Python in interactive shells
+export PATH="/opt/conda/bin:$PATH"
+EOF
+
+chmod 644 /etc/profile.d/conda-python.sh
+echo "Created /etc/profile.d/conda-python.sh for shell sessions"
+
+# Method 4: Update bashrc for non-login shells
+if [ -f /etc/bash.bashrc ]; then
+    if ! grep -q "/opt/conda/bin" /etc/bash.bashrc; then
+        # Add at the beginning to ensure priority
+        sed -i '1i export PATH="/opt/conda/bin:$PATH"' /etc/bash.bashrc
+        echo "Updated /etc/bash.bashrc"
+    fi
+fi
+
+echo "Python default configuration complete"


### PR DESCRIPTION
- New file: `images/base/set-python-default.sh`
  - Sets conda Python as default via PATH in `/etc/environment`, `/etc/profile.d/`, and `/etc/bash.bashrc`
  - Does NOT use update-alternatives (avoids breaking system tools)

- Modified: `images/base/Dockerfile`
  - Copies and runs the script
- Might not be necessary.