### PR TITLE
chore(workflows): add auto promote beta to master workflow

### DIFF
--- a/.github/workflows/beta-promote.yaml
+++ b/.github/workflows/beta-promote.yaml
@@ -1,4 +1,7 @@
 name: Promote Beta to Master
+permissions:
+  contents: read
+  pull-requests: write
 on:
   schedule:
     # Every wednesdays, at 2h30/3h30 am(EST/EDT)

--- a/.github/workflows/beta-promote.yaml
+++ b/.github/workflows/beta-promote.yaml
@@ -39,3 +39,52 @@ jobs:
         gh pr create --base master --title "chore: promote beta to master" \
           --body "Automatically generated PR to merge beta to master" \
           --label auto-deploy
+  
+  # Just run every Monday, as long as the is there. 
+  auto-promote-beta:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: "Promote BETA"
+      run: |
+        # Get list of PR numbers with label "approved for promotion"
+        # pr_list format is "1 24 43 11"
+        pr_list=$(gh pr list -l "approved for promotion" --json number --jq "[.[].number] | @sh")
+
+        for i in $pr_list
+        do
+            # for each PR, get their relevant info
+            prInfo=$(gh pr view $i --json baseRefName,mergeStateStatus,isDraft,mergeable,title,reviewDecision)
+            targetBranch=$(echo $prInfo | jq ".baseRefName")
+            mergeState=$(echo $prInfo | jq ".mergeStateStatus")
+            isDraft=$(echo $prInfo | jq ".isDraft")
+            isMergeable=$(echo $prInfo | jq ".mergeable")
+            title=$(echo $prInfo | jq ".title")
+            review=$(echo $prInfo | jq ".reviewDecision")
+
+            # if PR matches all our conditions, merge it
+            if [[ "$targetBranch" == '"master"'
+                && "$mergeState" == '"CLEAN"'
+                && $isDraft == false
+                && $isMergeable == '"MERGEABLE"'
+                && $review == '"APPROVED"' ]]; then
+                
+                echo "Merging PR #$i - $title"
+                gh pr merge $i
+            else
+                echo "NOT merging PR #$i - $title"
+                echo ""
+                echo "Target branch should be "beta": is $targetBranch"
+                echo "Merge state should be "CLEAN": is $mergeState"
+                echo "Should not be in draft. Is draft: $isDraft"
+                echo "Should be mergeable. Is mergeable: $isMergeable"
+                echo "Should be reviewed. Review is: $review"
+            fi
+            echo "----------------------------"
+        done
+


### PR DESCRIPTION
# Description

https://jirab.statcan.ca/browse/ZONE-375

## THIS MAY BE CHANGED, DO NOT DO THIS FIRST.
--> May do monthly releases, auto merge for example on Friday evening. 

# Tests / Quality Checks


# Beta Process
- [ ] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
