### PR TITLE
refactor(mid): optimize (gpt5.4 high)

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -141,6 +141,10 @@ RUN echo >> /opt/conda/ssl/cacert.pem \
 
 ENV REQUESTS_CA_BUNDLE=/opt/conda/ssl/cacert.pem
 
+# Ensure the image home stays owned by jovyan:user before we drop privileges.
+RUN install -d -o "${NB_USER}" -g "${NB_GID}" -m 2775 "${HOME}/.cache" \
+    && fix-permissions "/home/${NB_USER}"
+
 # s6 - copy scripts
 COPY --chown=${NB_USER}:${NB_GID} --chmod=755 s6/ /etc
 
@@ -216,9 +220,9 @@ COPY --chown=${NB_USER}:${NB_GID} vscode_user_settings.json ${HOME_TMP}/.local/s
 # https://jirab.statcan.ca/browse/ZPS-40
 COPY --chown=${NB_USER}:${NB_GID} --chmod=775 rm ${HOME_TMP}/.local/bin/rm
 
-RUN install -d -m 2775 "${HOME}/.cache" "${HOME_TMP}/.cache" \
+RUN install -d -m 2775 "${HOME_TMP}/.cache" \
     && chmod -R g=u "${HOME_TMP}" \
     && chmod 700 "${HOME_TMP}/.gnupg" \
-    && chmod 2775 "${HOME}/.cache" "${HOME_TMP}/.cache"
+    && chmod 2775 "${HOME_TMP}/.cache"
 
 EXPOSE 8888

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -182,10 +182,7 @@ RUN install -d -m 0775 \
     && DUCK_VER="$($DUCK_BIN --version | cut -d' ' -f1)" \
     && ABI_VER="v$(echo "$DUCK_VER" | sed 's/^v//' | cut -d'.' -f1-2).0" \
     && mkdir -p "${HOME_TMP}/.duckdb/extensions/${ABI_VER}/linux_amd64/" \
-    && $DUCK_BIN -c "INSTALL spatial; INSTALL httpfs; INSTALL icu; INSTALL avro; INSTALL parquet;" \
-    && chmod 700 "${HOME_TMP}/.gnupg" \
-    && chmod -R g=u "${HOME_TMP}" \
-    && chmod 2775 "${HOME_TMP}/.cache"
+    && $DUCK_BIN -c "INSTALL spatial; INSTALL httpfs; INSTALL icu; INSTALL avro; INSTALL parquet;"
 
 ENV EXTENSIONS_GALLERY='{"serviceUrl":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/api","itemUrl":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/item","resourceUrlTemplate":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/files/{publisher}/{name}/{version}/{path}"}'
 
@@ -203,9 +200,7 @@ RUN set -eu \
     && { \
         printf 'export GPG_TTY=$(tty)\n'; \
         printf 'eval "$(pixi completion --shell bash)"\n'; \
-    } >> "${HOME_TMP}/.bashrc" \
-    && chmod 700 "${HOME_TMP}/.gnupg" \
-    && chmod -R g=u "${HOME_TMP}"
+    } >> "${HOME_TMP}/.bashrc"
 
 # Copy over various files that should be restored into HOME on first boot.
 COPY --chown=${NB_USER}:${NB_GID} .Rprofile .profile .condarc connect-to-filer.md ${HOME_TMP}/
@@ -221,7 +216,9 @@ COPY --chown=${NB_USER}:${NB_GID} vscode_user_settings.json ${HOME_TMP}/.local/s
 # https://jirab.statcan.ca/browse/ZPS-40
 COPY --chown=${NB_USER}:${NB_GID} --chmod=775 rm ${HOME_TMP}/.local/bin/rm
 
-RUN chmod 700 "${HOME_TMP}/.gnupg" \
-    && chmod -R g=u "${HOME_TMP}"
+RUN install -d -m 2775 "${HOME}/.cache" "${HOME_TMP}/.cache" \
+    && chmod -R g=u "${HOME_TMP}" \
+    && chmod 700 "${HOME_TMP}/.gnupg" \
+    && chmod 2775 "${HOME}/.cache" "${HOME_TMP}/.cache"
 
 EXPOSE 8888

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -184,7 +184,8 @@ RUN install -d -m 0775 \
     && mkdir -p "${HOME_TMP}/.duckdb/extensions/${ABI_VER}/linux_amd64/" \
     && $DUCK_BIN -c "INSTALL spatial; INSTALL httpfs; INSTALL icu; INSTALL avro; INSTALL parquet;" \
     && chmod 700 "${HOME_TMP}/.gnupg" \
-    && chmod -R g=u "${HOME_TMP}"
+    && chmod -R g=u "${HOME_TMP}" \
+    && chmod 2775 "${HOME_TMP}/.cache"
 
 ENV EXTENSIONS_GALLERY='{"serviceUrl":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/api","itemUrl":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/item","resourceUrlTemplate":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/files/{publisher}/{name}/{version}/{path}"}'
 

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -85,6 +85,8 @@ RUN mamba install --quiet --yes -c conda-forge \
         'pyspark[ml]==3.5.5' \
     && /opt/conda/bin/R --silent --slave --no-save --no-restore -e 'install.packages("languageserver", repos="https://cran.r-project.org/")' \
     && jupyter server extension enable --sys-prefix --py jupyter_server_proxy \
+    && jupyter lab build --dev-build=False --minimize=False \
+    && jupyter lab clean \
     && npm i -g \
         'bash-language-server' \
         'dockerfile-language-server-nodejs' \
@@ -147,11 +149,18 @@ USER $NB_USER
 # Build the first-boot home skeleton as jovyan so user-writable content is created
 # from the same context that will later consume it on mounted storage.
 RUN install -d -m 0775 \
+    "${HOME_TMP}/.cache" \
+    "${HOME_TMP}/.cache/pip" \
     "${HOME_TMP}/.config/rstudio" \
+    "${HOME_TMP}/.config/pip" \
     "${HOME_TMP}/.gnupg" \
+    "${HOME_TMP}/.ipython" \
+    "${HOME_TMP}/.jupyter" \
     "${HOME_TMP}/.local/bin" \
+    "${HOME_TMP}/.local/share/rstudio" \
     "${HOME_TMP}/.local/share/code-server/Machine" \
     "${HOME_TMP}/.local/share/code-server/User" \
+    "${HOME_TMP}/.rstudio" \
     "${HOME_TMP}/workspace/.vscode" \
     "${HOME_TMP}/workspace/data" \
     "${HOME_TMP}/workspace/repositories" \

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -6,150 +6,97 @@ FROM $BASE_IMAGE
 
 USER root
 
-# installs vscode server, python & conda packages and jupyter lab extensions.
-# also installs r-studio and pixi
-
-# Using JupyterLab 3.0 inherited docker-stacks base image. A few extensions we used to install and don't support
-# this version of Jupyterlab and/or are not OL-compliant so they have been removed until new compatible versions are available:
-# jupyterlab-kale
-# jupyterlab-variableinspector
-# jupyterlab-archive
-# jupyterlab-spellchecker
-# jupyterlab-spreadsheet
+# installs vscode server, python & conda packages, jupyter tooling, RStudio, and pixi
 
 # Install vscode
 ARG VSCODE_VERSION=4.99.4
 ARG VSCODE_SHA=74c107b33643ed11223263b86431530fbc9c9f7c8202997579a6f0c41b4cb102
 ARG VSCODE_URL=https://github.com/coder/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 
-ENV CS_DISABLE_FILE_DOWNLOADS=1
-ENV CS_DEFAULT_HOME=$HOME/.local/share/code-server
-ENV SERVICE_URL=https://extensions.coder.com/api
+ENV CS_DISABLE_FILE_DOWNLOADS=1 \
+    CS_DEFAULT_HOME=$HOME/.local/share/code-server \
+    SERVICE_URL=https://extensions.coder.com/api
 
-# System operations and cleanup
+# Install code-server and supporting system packages.
 RUN wget -q "${VSCODE_URL}" -O ./vscode.deb \
     && echo "${VSCODE_SHA}  ./vscode.deb" | sha256sum -c - \
-    && wget -q https://github.com/microsoft/vscode-cpptools/releases/download/v1.20.5/cpptools-linux.vsix \
     && apt-get update \
     && apt-get install -y --no-install-recommends nginx build-essential gdb sqlite3 openmpi-bin libopenmpi-dev \
     && dpkg -i ./vscode.deb \
     && rm ./vscode.deb \
     && rm -f /etc/apt/sources.list.d/vscode.list \
-    && mkdir -p $CS_DEFAULT_HOME/Machine \
-    && \
-    # Manage extensions
-    code-server --install-extension ms-python.python@2025.4.0 && \
-    code-server --install-extension ms-python.debugpy@2025.4.0 && \
-    code-server --install-extension Posit.air-vscode@0.22.0 && \
-    code-server --install-extension ms-ceintl.vscode-language-pack-fr@1.99.0 && \
-    code-server --install-extension adamviola.parquet-explorer@1.2.1 && \
-    code-server --install-extension lucien-martijn.parquet-visualizer@0.31.1 && \
-    code-server --install-extension redhat.vscode-yaml@1.15.0 && \
-    code-server --install-extension ms-vscode.azurecli@0.6.0 && \
-    code-server --install-extension mblode.pretty-formatter@0.2.1 && \
-    code-server --install-extension cpptools-linux.vsix \
-    && rm cpptools-linux.vsix \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && fix-permissions $CS_DEFAULT_HOME
+    && rm -rf /var/lib/apt/lists/*
 
-ENV EXTENSIONS_GALLERY='{"serviceUrl":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/api","itemUrl":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/item","resourceUrlTemplate":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/files/{publisher}/{name}/{version}/{path}"}'
-COPY vscode-overrides.json $CS_DEFAULT_HOME/Machine/settings.json
+COPY --chown=${NB_USER}:${NB_GID} vscode-overrides.json ${HOME_TMP}/.local/share/code-server/Machine/settings.json
 # Fix for VSCode extensions and CORS
 # Languagepacks.json needs to exist for code-server to recognize the languagepack
 # Sets the default workspace for vscode
-COPY languagepacks.json coder.json $CS_DEFAULT_HOME/
+COPY --chown=${NB_USER}:${NB_GID} languagepacks.json coder.json ${HOME_TMP}/.local/share/code-server/
 
-# Install Python dependencies and tools
-# https://github.com/StatCan/aaw-kubeflow-containers/issues/293
-# https://stackoverflow.com/questions/68824450/error-configuration-failed-for-package-ragg
-# need to add mamba install pkg-config so R can find freetype related packages
-# Combined conda and pip installations with cleanup
+# Install Python dependencies, language tooling, and Jupyter server integration.
+# Keep package manager cleanup in the same layer as the install work.
 RUN mamba install --quiet --yes -c conda-forge \
-    'sqlite>=3.45' \
-    'pillow' \
-    'pyyaml' \
-    'joblib==1.2.0' \
-    's3fs' \
-    'fire' \
-    'mkl' \
-    'graphviz' \
-    'nodejs' \
-    'pkg-config' \
-    'jupyterlab' \
-    'dash' \
-    'plotly' \
-    'ipywidgets' \
-    'markupsafe' \
-    'ipympl' \
-    'pexpect==4.9.0' \
-    'jupyter-resource-usage' \
-    'jupyter-server-proxy==4.2.0' \
-    'jupyterlab-language-pack-fr-fr' \
-    'jupyterlab_execute_time' \
-    'nb_conda_kernels' \
-    'jupyterlab-lsp' \
-    'jupyter-lsp' \
-    'r-arrow' \
-    'r-aws.s3' \
-    'r-base=4.5.1' \
-    'r-catools' \
-    'r-e1071' \
-    'r-hdf5r' \
-    'r-markdown' \
-    'r-odbc' \
-    'r-renv' \
-    'r-rodbc' \
-    'r-sf' \
-    'r-sparklyr' \
-    'r-tidyverse' \
-    'duckdb' \
-    'duckdb-cli' \
-    'python-duckdb' \
+        'sqlite>=3.45' \
+        'pillow' \
+        'pyyaml' \
+        'joblib==1.2.0' \
+        's3fs' \
+        'fire' \
+        'mkl' \
+        'graphviz' \
+        'nodejs' \
+        'pkg-config' \
+        'jupyterlab' \
+        'dash' \
+        'plotly' \
+        'ipywidgets' \
+        'markupsafe' \
+        'ipympl' \
+        'pexpect==4.9.0' \
+        'jupyter-resource-usage' \
+        'jupyter-server-proxy==4.2.0' \
+        'jupyterlab-language-pack-fr-fr' \
+        'jupyterlab_execute_time' \
+        'nb_conda_kernels' \
+        'jupyterlab-lsp' \
+        'jupyter-lsp' \
+        'python-lsp-server' \
+        'r-arrow' \
+        'r-aws.s3' \
+        'r-base=4.5.1' \
+        'r-catools' \
+        'r-e1071' \
+        'r-hdf5r' \
+        'r-markdown' \
+        'r-odbc' \
+        'r-renv' \
+        'r-rodbc' \
+        'r-sf' \
+        'r-sparklyr' \
+        'r-tidyverse' \
+        'duckdb' \
+        'duckdb-cli' \
+        'python-duckdb' \
     && pip install --no-cache-dir \
-    'kubeflow-training' \
-    'git+https://github.com/betatim/vscode-binder' \
-    'jupyter-rsession-proxy==2.2.0' \
-    'pyspark[ml]==3.5.5' \
-    && jupyter server extension enable --py jupyter_server_proxy \
-    && jupyter labextension enable \
-    '@jupyterlab/translation-extension' \
-    '@jupyterlab/server-proxy' \
-    'nbdime-jupyterlab' \
-    && jupyter lab build \
-    && jupyter lab clean \
+        'kubeflow-training' \
+        'git+https://github.com/betatim/vscode-binder' \
+        'jupyter-rsession-proxy==2.2.0' \
+        'pyspark[ml]==3.5.5' \
+    && /opt/conda/bin/R --silent --slave --no-save --no-restore -e 'install.packages("languageserver", repos="https://cran.r-project.org/")' \
+    && jupyter server extension enable --sys-prefix --py jupyter_server_proxy \
+    && npm i -g \
+        'bash-language-server' \
+        'dockerfile-language-server-nodejs' \
+        'javascript-typescript-langserver' \
+        'unified-language-server' \
+        'yaml-language-server' \
     && clean-layer.sh \
-    && rm -rf /home/$NB_USER/.cache/yarn \
-    && rm -rf /home/$NB_USER/.node-gyp \
-    && fix-permissions $CONDA_DIR \
-    && fix-permissions /home/$NB_USER
+    && rm -rf /root/.cache /root/.npm \
+    && fix-permissions $CONDA_DIR
 
 # Install DuckDB extensions for parquet visualizer (air-gapped support)
-COPY --chown=${NB_USER}:${NB_GID} .duckdbrc /home/$NB_USER/.duckdbrc
-
-RUN DUCK_BIN="/opt/conda/bin/duckdb" && \
-    DUCK_VER=$($DUCK_BIN --version | cut -d' ' -f1) && \
-    ABI_VER=v$(echo $DUCK_VER | cut -d'.' -f1-2).0 && \
-    mkdir -p /home/$NB_USER/.duckdb/extensions/${ABI_VER}/linux_amd64/ && \
-    # duckdb extensions required by parquet visualizer:
-    $DUCK_BIN -c "INSTALL spatial; INSTALL httpfs; INSTALL icu; INSTALL avro; INSTALL parquet;" && \
-    chown -R $NB_USER:$NB_GID /home/$NB_USER/.duckdb
-
-# Install python, R, Julia and other useful language servers
-RUN julia -e 'using Pkg; Pkg.add("LanguageServer")' \
-    && /opt/conda/bin/R --silent --slave --no-save --no-restore -e 'install.packages("languageserver", repos="https://cran.r-project.org/")' \
-    && mamba install -c conda-forge --quiet --yes 'python-lsp-server' \
-    && npm i -g \
-    'bash-language-server'  \
-    'dockerfile-language-server-nodejs' \
-    'javascript-typescript-langserver' \
-    'unified-language-server' \
-    'yaml-language-server' \
-    && npm cache clean --force \
-    && rm -rf /root/.npm \
-    && clean-layer.sh \ 
-    && fix-permissions $CONDA_DIR \
-    && fix-permissions /home/$NB_USER
+COPY --chown=${NB_USER}:${NB_GID} .duckdbrc ${HOME_TMP}/.duckdbrc
 
 # Solarized Theme and Cell Execution Time
 COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.json
@@ -157,16 +104,15 @@ COPY jupyterlab-overrides.json /opt/conda/share/jupyter/lab/settings/overrides.j
 # install rstudio-server
 ARG RSTUDIO_VERSION=2025.09.1-401
 ARG SHA256=9a6b1ccf05a62e13bb7cab26b9ef5ba01445b58abb4a9f2c9868855e33613f1b
-# RStudio installation with cleanup
 RUN apt-get update \
-    && apt install -y --no-install-recommends software-properties-common dirmngr gdebi-core \
-    && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
-    && add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/" \
-    && apt-get update && apt-get -y dist-upgrade \
-    && curl --silent -L  --fail "https://s3.amazonaws.com/rstudio-ide-build/server/jammy/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" > /tmp/rstudio.deb \
+    && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/cran_ubuntu_key.gpg \
+    && echo "deb [signed-by=/etc/apt/trusted.gpg.d/cran_ubuntu_key.gpg] https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" > /etc/apt/sources.list.d/cran-r.list \
+    && apt-get update \
+    && curl --silent -L --fail "https://s3.amazonaws.com/rstudio-ide-build/server/jammy/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb" > /tmp/rstudio.deb \
     && echo "${SHA256} /tmp/rstudio.deb" | sha256sum -c - \
     && apt-get install --no-install-recommends -y /tmp/rstudio.deb \
     && rm /tmp/rstudio.deb \
+    && rm -f /etc/apt/sources.list.d/cran-r.list /etc/apt/trusted.gpg.d/cran_ubuntu_key.gpg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -174,76 +120,98 @@ RUN apt-get update \
 # See: https://github.com/rstudio/rstudio/issues/14060 for rsession-ld-library-path
 COPY rserver.conf rsession.conf /etc/rstudio/
 
-# Disables .RData settings
-RUN mkdir -p ${HOME}/.config/rstudio
-COPY --chown=${NB_USER}:${NB_GID} rstudio-prefs.json ${HOME}/.config/rstudio/rstudio-prefs.json
+COPY --chown=${NB_USER}:${NB_GID} rstudio-prefs.json ${HOME_TMP}/.config/rstudio/rstudio-prefs.json
 
-ENV PATH=$PATH:/usr/lib/rstudio-server/bin
-
-ENV SPARK_HOME="/opt/conda/lib/python3.13/site-packages/pyspark"
-ENV R_ZIPCMD="zip"
-
-# install pixi package manager and enable autocomplete
-
-RUN wget -qO- https://pixi.sh/install.sh | sh \
-    && echo "eval \"\$(pixi completion --shell bash)\"" >> ~/.bashrc
+ENV PATH=$PATH:/usr/lib/rstudio-server/bin \
+    SPARK_HOME="/opt/conda/lib/python3.13/site-packages/pyspark" \
+    R_ZIPCMD="zip"
 
 # Configure container startup
-
-# Copy over pip config
-COPY --chown=${NB_USER}:${NB_GID} pip.conf /etc/pip.conf
-
-#Copy over various files
-COPY --chown=${NB_USER}:${NB_GID} .Rprofile .profile .condarc connect-to-filer.md ${HOME}/
-
+COPY pip.conf /etc/pip.conf
 COPY --chmod=755 keep-alive.sh /usr/local/bin/
 
 # SSL Certs
 # https://jirab.statcan.ca/browse/ZONE-274?focusedId=3674862&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3674862
 COPY --from=k8scc01covidacr.azurecr.io/publiccerts:latest /home/certs/ /opt/conda/ssl/certs
-RUN echo >> /opt/conda/ssl/cacert.pem && \
-    cd /opt/conda/ssl/certs/ && \
-    for file in *.crt; do (echo "# ${file}"; cat "${file}"; echo) >> /opt/conda/ssl/cacert.pem; done
+RUN echo >> /opt/conda/ssl/cacert.pem \
+    && cd /opt/conda/ssl/certs/ \
+    && for file in *.crt; do (echo "# ${file}"; cat "${file}"; echo) >> /opt/conda/ssl/cacert.pem; done
 
 ENV REQUESTS_CA_BUNDLE=/opt/conda/ssl/cacert.pem
-
-USER $NB_USER
-
-# Setup default user env
-RUN mkdir -p ${HOME}/workspace \
-    && mkdir -p ${HOME}/workspace/repositories \
-    && mkdir -p ${HOME}/workspace/data \
-    && mkdir -p ${HOME}/workspace/.vscode \
-    && mkdir -p ${HOME}/.local/share/code-server/User \
-    # Step up Git Credential Manager
-    && git config --global credential.credentialStore gpg \
-    && git config --global credential.helper manager \
-    && echo "export GPG_TTY=\$(tty)" >> ${HOME}/.bashrc \
-    # Create and set the gpg settings during first boot
-    && mkdir -p ${HOME}/.gnupg \
-    && chmod 700 "${HOME}/.gnupg"
-
-COPY --chown=${NB_USER}:${NB_GID} gpg-agent.conf ${HOME}/.gnupg/gpg-agent.conf
-
-# Set Python interpreter path for VSCode
-COPY --chown=${NB_USER}:${NB_GID} vscode_settings.json ${HOME}/workspace/.vscode/settings.json
-
-# Python default user settings for VSCode
-COPY --chown=${NB_USER}:${NB_GID} vscode_user_settings.json ${HOME}/.local/share/code-server/User/settings.json
-
-# add rm wrapper
-# https://jirab.statcan.ca/browse/ZPS-40
-COPY --chown=${NB_USER}:${NB_GID} --chmod=775 rm ${HOME}/.local/bin/rm
 
 # s6 - copy scripts
 COPY --chown=${NB_USER}:${NB_GID} --chmod=755 s6/ /etc
 
-# s6 - 01-copy-tmp-home
-# NOTE: the contents of $HOME_TMP are copied to $HOME at runtime
-#       this is a workaround because a PVC will be mounted at $HOME
-#       and the contents of $HOME will be hidden
-RUN cp -p -r -T "${HOME}" "${HOME_TMP}" \
-    # give group same access as user (needed for OpenShift)
+USER $NB_USER
+
+# Build the first-boot home skeleton as jovyan so user-writable content is created
+# from the same context that will later consume it on mounted storage.
+RUN install -d -m 0775 \
+    "${HOME_TMP}/.config/rstudio" \
+    "${HOME_TMP}/.gnupg" \
+    "${HOME_TMP}/.local/bin" \
+    "${HOME_TMP}/.local/share/code-server/Machine" \
+    "${HOME_TMP}/.local/share/code-server/User" \
+    "${HOME_TMP}/workspace/.vscode" \
+    "${HOME_TMP}/workspace/data" \
+    "${HOME_TMP}/workspace/repositories" \
+    && export HOME="${HOME_TMP}" \
+    && wget -q https://github.com/microsoft/vscode-cpptools/releases/download/v1.20.5/cpptools-linux.vsix -O "${HOME_TMP}/cpptools-linux.vsix" \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension ms-python.python@2025.4.0 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension ms-python.debugpy@2025.4.0 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension Posit.air-vscode@0.22.0 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension ms-ceintl.vscode-language-pack-fr@1.99.0 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension adamviola.parquet-explorer@1.2.1 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension lucien-martijn.parquet-visualizer@0.31.1 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension redhat.vscode-yaml@1.15.0 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension ms-vscode.azurecli@0.6.0 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension mblode.pretty-formatter@0.2.1 \
+    && CS_DEFAULT_HOME="${HOME_TMP}/.local/share/code-server" code-server --install-extension "${HOME_TMP}/cpptools-linux.vsix" \
+    && rm -f "${HOME_TMP}/cpptools-linux.vsix" \
+    && wget -qO- https://pixi.sh/install.sh | sh \
+    && DUCK_BIN="/opt/conda/bin/duckdb" \
+    && DUCK_VER="$($DUCK_BIN --version | cut -d' ' -f1)" \
+    && ABI_VER="v$(echo "$DUCK_VER" | sed 's/^v//' | cut -d'.' -f1-2).0" \
+    && mkdir -p "${HOME_TMP}/.duckdb/extensions/${ABI_VER}/linux_amd64/" \
+    && $DUCK_BIN -c "INSTALL spatial; INSTALL httpfs; INSTALL icu; INSTALL avro; INSTALL parquet;" \
+    && chmod 700 "${HOME_TMP}/.gnupg" \
+    && chmod -R g=u "${HOME_TMP}"
+
+ENV EXTENSIONS_GALLERY='{"serviceUrl":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/api","itemUrl":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/item","resourceUrlTemplate":"https://code-marketplace.thezone-prod-cc-00.cloudnative.cloud.statcan.ca/files/{publisher}/{name}/{version}/{path}"}'
+
+# Seed first-boot home defaults without cloning large runtime-managed directories.
+RUN set -eu \
+    && for entry in "${HOME}"/* "${HOME}"/.[!.]* "${HOME}"/..?*; do \
+        [ -e "${entry}" ] || continue; \
+        case "$(basename "${entry}")" in \
+            .cache|.conda|.duckdb|.duckdbrc|.gnupg|.julia|.local|.mamba|.npm|.pixi|workspace) continue ;; \
+        esac; \
+        cp -r --update=none "${entry}" "${HOME_TMP}/"; \
+    done \
+    && git config --file "${HOME_TMP}/.gitconfig" credential.credentialStore gpg \
+    && git config --file "${HOME_TMP}/.gitconfig" credential.helper manager \
+    && { \
+        printf 'export GPG_TTY=$(tty)\n'; \
+        printf 'eval "$(pixi completion --shell bash)"\n'; \
+    } >> "${HOME_TMP}/.bashrc" \
+    && chmod 700 "${HOME_TMP}/.gnupg" \
+    && chmod -R g=u "${HOME_TMP}"
+
+# Copy over various files that should be restored into HOME on first boot.
+COPY --chown=${NB_USER}:${NB_GID} .Rprofile .profile .condarc connect-to-filer.md ${HOME_TMP}/
+COPY --chown=${NB_USER}:${NB_GID} gpg-agent.conf ${HOME_TMP}/.gnupg/gpg-agent.conf
+
+# Set Python interpreter path for VSCode
+COPY --chown=${NB_USER}:${NB_GID} vscode_settings.json ${HOME_TMP}/workspace/.vscode/settings.json
+
+# Python default user settings for VSCode
+COPY --chown=${NB_USER}:${NB_GID} vscode_user_settings.json ${HOME_TMP}/.local/share/code-server/User/settings.json
+
+# add rm wrapper
+# https://jirab.statcan.ca/browse/ZPS-40
+COPY --chown=${NB_USER}:${NB_GID} --chmod=775 rm ${HOME_TMP}/.local/bin/rm
+
+RUN chmod 700 "${HOME_TMP}/.gnupg" \
     && chmod -R g=u "${HOME_TMP}"
 
 EXPOSE 8888

--- a/tests/mid/test_parquet.py
+++ b/tests/mid/test_parquet.py
@@ -26,6 +26,8 @@ Example:
 import logging
 import pytest
 
+from tests.general.wait_utils import wait_for_exec_success
+
 LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.integration
@@ -45,6 +47,21 @@ def test_parquet_functionality(container):
         pytest.skip("Parquet functionality not expected in base image")
     
     LOGGER.info("Testing parquet functionality...")
+
+    container.run()
+
+    success, output = wait_for_exec_success(
+        container=container,
+        command=["python3", "--version"],
+        timeout=30,
+        initial_delay=0.5,
+        max_delay=3.0
+    )
+
+    if not success:
+        raise AssertionError(
+            f"Container failed to be ready for execution within timeout. Output: {output}"
+        )
     
     # Create a simple Python script to test parquet functionality
     test_script = '''

--- a/tests/mid/test_vscode_extensions.py
+++ b/tests/mid/test_vscode_extensions.py
@@ -25,6 +25,8 @@ Example:
 import logging
 import pytest
 
+from tests.general.wait_utils import wait_for_exec_success
+
 LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.integration
@@ -44,6 +46,21 @@ def test_vscode_extensions_installed(container):
         pytest.skip("VSCode extensions not expected in base image")
     
     LOGGER.info("Testing VSCode extensions installation...")
+
+    container.run()
+
+    success, output = wait_for_exec_success(
+        container=container,
+        command=["which", "code-server"],
+        timeout=30,
+        initial_delay=0.5,
+        max_delay=3.0
+    )
+
+    if not success:
+        raise AssertionError(
+            f"Container failed to be ready for execution within timeout. Output: {output}"
+        )
     
     # Check if code-server is available
     result = container.container.exec_run(["which", "code-server"])

--- a/tests/mid/test_vscode_extensions.py
+++ b/tests/mid/test_vscode_extensions.py
@@ -78,9 +78,8 @@ def test_vscode_extensions_installed(container):
     expected_extensions = [
         "ms-python.python",
         "ms-python.debugpy",
-        "REditorSupport.r",
+        "Posit.air-vscode",
         "ms-ceintl.vscode-language-pack-fr",
-        "quarto.quarto",
         "adamviola.parquet-explorer",
         "lucien-martijn.parquet-visualizer",
         "redhat.vscode-yaml",

--- a/tests/mid/test_vscode_extensions.py
+++ b/tests/mid/test_vscode_extensions.py
@@ -78,7 +78,7 @@ def test_vscode_extensions_installed(container):
     expected_extensions = [
         "ms-python.python",
         "ms-python.debugpy",
-        "Posit.air-vscode",
+        "posit.air-vscode",
         "ms-ceintl.vscode-language-pack-fr",
         "adamviola.parquet-explorer",
         "lucien-martijn.parquet-visualizer",


### PR DESCRIPTION

## Summary
This PR refactors the `images/mid/Dockerfile` to streamline how the MID image is built and initialized. The changes mainly reorganize installation and setup steps for code-server, Jupyter tooling, RStudio, language servers, DuckDB, Pixi, and the first-boot home skeleton used when a PVC hides the baked-in home directory.

## Main changes
- Consolidates several environment variable definitions and installation steps to reduce Dockerfile sprawl.
- Moves more user-scoped config and seeded home content into `HOME_TMP` so it can be restored cleanly at runtime.
- Reworks VS Code extension installation to happen from the user-side seeded home context instead of the earlier root-owned path.
- Folds language-server setup and related tooling into the main dependency/build flow.
- Simplifies RStudio installation by using a scoped CRAN key/repo setup and cleaning it up afterward.
- Keeps DuckDB, Pixi, workspace defaults, and other first-boot assets aligned with the temporary home skeleton approach.

## Other Fixes Included
Later commits in the PR specifically address permissions and cleanup, including:
- `.cache` permission fixes
- cleanup of duplicate permission bindings
- moving `.cache` chmod handling to the root phase

### Test Image
artifactory.cloud.statcan.ca/das-aaw-docker/jupyterlab-cpu:docker-mid-refactor