### PR TITLE
WIP(beta images to new image repo)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,6 +22,11 @@ on:
       - "!tests/README.md"
       - "requirements-dev.txt"
 
+# Need to distinguish in this job between pushes to master (aka v2) and beta / pull requests
+# This is for the aim of having two different image repos, one for master and another for beta / prs
+# Example: We want a `base` and a `base-beta`. This will make it easy to script aggressive cleanup for 
+## the images pushed to `base-beta` without worrying about affecting `base`
+## `base` will still have a cleanup task, but it will be less aggressive.
 jobs:
   vars:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,9 +47,22 @@ jobs:
   base:
     needs: [vars]
     uses: ./.github/workflows/docker-steps.yaml
+    # if we could use a conditional on this with itd be cool
+    # no else https://stackoverflow.com/questions/60916931/github-actions-does-the-if-have-an-else
+    if: ${{ branch-name == 'master' }}
     with:
       image: "base"
       directory: "base"
+      base-image: "quay.io/jupyter/datascience-notebook:2025-08-15"
+      registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
+      branch-name: "${{ needs.vars.outputs.branch-name }}"
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+    if: ${{ branch-name != 'master' }}
+    with:
+      image: "base-beta"
+      directory: "base-beta"
       base-image: "quay.io/jupyter/datascience-notebook:2025-08-15"
       registry-name: "${{ needs.vars.outputs.REGISTRY_NAME }}"
       branch-name: "${{ needs.vars.outputs.branch-name }}"

--- a/images/mid/s6/cont-init.d/02-start-custom
+++ b/images/mid/s6/cont-init.d/02-start-custom
@@ -33,8 +33,6 @@ serviceaccountname=`kubectl get secret artifactory-creds -n $NB_NAMESPACE --temp
 serviceaccounttoken=`kubectl get secret artifactory-creds -n $NB_NAMESPACE --template={{.data.Token}} | base64 --decode`
 # Point conda to Artifactory repository
 conda config --add channels https://$serviceaccountname:$serviceaccounttoken@artifactory.cloud.statcan.ca/artifactory/conda-forge-remote/
-conda config --add channels https://$serviceaccountname:$serviceaccounttoken@artifactory.cloud.statcan.ca/artifactory/conda-pytorch-remote/
-conda config --add channels https://$serviceaccountname:$serviceaccounttoken@artifactory.cloud.statcan.ca/artifactory/conda-nvidia-remote/
 conda config --remove channels 'defaults'
 conda config --remove channels conda-forge --system
 


### PR DESCRIPTION
# Description

https://jirab.statcan.ca/browse/ZONE-438

Updates the workflow for beta images to push to a new image repo. Probs have to extend current logic to next ones. 

# Tests / Quality Checks


# Beta Process
- [ ] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
