### PR TITLE
fix: added mitigation for cve

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,6 @@
 target "base" {
     args = {
-        BASE_IMAGE="quay.io/jupyter/datascience-notebook:2025-03-05"
+        BASE_IMAGE="quay.io/jupyter/datascience-notebook:2025-08-15"
     }
     context = "./images/base"
     tags = ["base"]

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -214,6 +214,11 @@ COPY dbConnection/sqlnet.ora ${TNS_ADMIN}/sqlnet.ora
 RUN chmod a+w ${TNS_ADMIN} \
     && chown $NB_UID:$NB_GID ${TNS_ADMIN}/tnsnames.ora
 
+# CVE-2026-31431
+# https://copy.fail/#mitigation
+RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf \
+    && rmmod algif_aead 2>/dev/null || true
+
 # Final cleanup
 RUN rm -rf /tmp/* /var/tmp/* \
     && find / -depth -name '*.pyc' -exec rm -rf '{}' + \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -216,7 +216,8 @@ RUN chmod a+w ${TNS_ADMIN} \
 
 # CVE-2026-31431
 # https://copy.fail/#mitigation
-RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf \
+RUN mkdir -p /etc/modprobe.d \
+    && echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf \
     && rmmod algif_aead 2>/dev/null || true
 
 # Final cleanup


### PR DESCRIPTION
# Description

for https://jirab.statcan.ca/browse/ZONE-471

# Tests / Quality Checks


# Beta Process
- [ ] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
