### PR TITLE
feat: OneLake notebook helper (CLI + JupyterLab drive), reusing the zone token broker

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -117,6 +117,29 @@ RUN set -eux; \
     rm -rf /tmp/zone-token-broker; \
     fix-permissions "${CONDA_DIR}"
 
+# OneLake helper — `onelake` CLI, `import onelake` Python client, `library(onelake)`
+# R wrappers, and the clickable JupyterLab "OneLake" drive (jupyter-fs + fsspec).
+# Delegated auth is reused from the zone_token_broker installed above; this layer
+# adds no broker of its own. The per-user .local/share/jupyter dir is pre-created
+# (NB_USER-owned, setgid) so jupyter-fs can persist state on the mounted home
+# volume. See images/mid/onelake/README.md.
+COPY onelake /tmp/onelake
+RUN set -eux; \
+    pip install --no-cache-dir \
+        'azure-storage-file-datalake' \
+        'jupyter-fs[fsspec]==1.1.2'; \
+    purelib="$(/opt/conda/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
+    cp /tmp/onelake/*.py "$purelib/"; \
+    printf '%s\n' 'import onelake_register' > "$purelib/onelake_fsspec_register.pth"; \
+    install -m 0755 /tmp/onelake/onelake /usr/local/bin/onelake; \
+    /opt/conda/bin/R CMD INSTALL /tmp/onelake/onelake-r; \
+    install -d -m 0755 /etc/jupyter/jupyter_server_config.d; \
+    install -m 0644 /tmp/onelake/jupyter_server_config.d/onelake.json /etc/jupyter/jupyter_server_config.d/onelake.json; \
+    install -d -o "${NB_USER}" -g "${NB_GID}" -m 2775 "/home/${NB_USER}/.local/share/jupyter"; \
+    rm -rf /tmp/onelake; \
+    fix-permissions "${CONDA_DIR}"; \
+    fix-permissions "/home/${NB_USER}"
+
 # Install DuckDB extensions for parquet visualizer (air-gapped support)
 COPY --chown=${NB_USER}:${NB_GID} .duckdbrc ${HOME_TMP}/.duckdbrc
 

--- a/images/mid/onelake/README.md
+++ b/images/mid/onelake/README.md
@@ -1,0 +1,79 @@
+# OneLake for Zone notebooks
+
+A small helper so notebook users can browse and move OneLake files using their
+own signed-in permissions, without writing Microsoft auth or Azure SDK
+boilerplate. Installed in the `mid` image, so every notebook image inherits it.
+
+## How it fits together
+
+```text
+JupyterLab "OneLake" drive   Python: import onelake   R: library(onelake)   CLI: onelake
+                         \            |              /                /
+                          \           |             /                /
+                                  onelake.py  (one small Python client)
+                                        |
+                          zone_token_broker  (shared helper, installed in mid)
+                                        |
+                          AuthService /authservice/getPassthroughToken?scope=...
+                                        |
+                          Azure Data Lake SDK  ->  OneLake DFS endpoint
+```
+
+- **Auth is delegated.** Tokens come from the in-cluster AuthService via the
+  shared `zone_token_broker` module — the same broker every Zone consumer uses.
+  This module does **not** ship its own broker. Tokens stay in memory; only the
+  workspace/lakehouse selection is persisted (`~/.onelake/config.json`).
+- **One client.** `onelake.py` is the single code path. The CLI, the R wrappers,
+  and the JupyterLab drive all go through it.
+
+## Public surface
+
+CLI (`onelake`):
+
+```bash
+onelake status [--live]
+onelake connect <workspace> <lakehouse>
+onelake ls [path]
+onelake cat <path>
+onelake write <path>          # reads stdin
+onelake get <remote> <local>
+onelake put <local> <remote>
+```
+
+Python (`import onelake`): `connect`, `status`, `ls`, `read`, `write`,
+`download`, `upload`. Files also open directly through fsspec, e.g.
+`pandas.read_csv("onelake://Files/raw/input.csv")`.
+
+R (`library(onelake)`): `ol_connect`, `ol_status`, `ol_ls`, `ol_read_text`,
+`ol_write_text`, `ol_download`, `ol_upload` — thin shells over the CLI, no
+duplicated token logic.
+
+## Path model
+
+The user-facing root is synthetic. `Files/` and `Tables/` are the managed
+roots; any other path is treated as relative to `Files/`. Writes must target a
+file inside `Files/` or `Tables/`.
+
+## Environment
+
+All optional; `connect` is the normal way to set the workspace/lakehouse.
+
+- `ONELAKE_WORKSPACE`, `ONELAKE_LAKEHOUSE` — override the saved selection (env
+  wins over `~/.onelake/config.json`).
+- `ONELAKE_REGION` (default `canadacentral`) / `ONELAKE_ENDPOINT` — the OneLake
+  DFS endpoint.
+- `AUTHSERVICE_BROKER_URL` — override the AuthService base URL (from the shared
+  `zone_token_broker`; defaults to the in-cluster AuthService).
+
+## Future: folder shortcuts and a click-only GUI
+
+The JupyterLab drive (`onelake_fsspec.py` + jupyter-fs) is the first step toward
+a fully graphical experience: see OneLake folders in the file browser and open,
+edit, and save by clicking. The next steps build on this same client —
+registering OneLake **folder shortcuts** as named drives and a richer in-notebook
+browser — without changing the auth or path model below it.
+
+## Non-goals
+
+No FUSE/BlobFuse mounts, no device-code/Azure CLI login, no user-facing token
+commands, no service-principal data access, and no Delta/transaction logic.

--- a/images/mid/onelake/jupyter_server_config.d/onelake.json
+++ b/images/mid/onelake/jupyter_server_config.d/onelake.json
@@ -1,0 +1,19 @@
+{
+  "ServerApp": {
+    "contents_manager_class": "jupyterfs.metamanager.MetaManager",
+    "jpserver_extensions": {
+      "jupyterfs.extension": true
+    }
+  },
+  "JupyterFs": {
+    "resources": [
+      {
+        "name": "OneLake",
+        "url": "onelake:///",
+        "type": "fsspec",
+        "auth": "none",
+        "defaultWritable": true
+      }
+    ]
+  }
+}

--- a/images/mid/onelake/onelake
+++ b/images/mid/onelake/onelake
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+from onelake_cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/images/mid/onelake/onelake-r/DESCRIPTION
+++ b/images/mid/onelake/onelake-r/DESCRIPTION
@@ -1,0 +1,9 @@
+Package: onelake
+Type: Package
+Title: OneLake Helpers
+Version: 0.1.0
+Authors@R: person("Statistics Canada", role = c("aut", "cre"), email = "statcan@example.invalid")
+Description: Thin R wrappers around the onelake command line helper.
+License: MIT
+Encoding: UTF-8
+RoxygenNote: 7.3.0

--- a/images/mid/onelake/onelake-r/NAMESPACE
+++ b/images/mid/onelake/onelake-r/NAMESPACE
@@ -1,0 +1,7 @@
+export(ol_connect)
+export(ol_status)
+export(ol_ls)
+export(ol_read_text)
+export(ol_write_text)
+export(ol_download)
+export(ol_upload)

--- a/images/mid/onelake/onelake-r/R/onelake.R
+++ b/images/mid/onelake/onelake-r/R/onelake.R
@@ -1,0 +1,50 @@
+ol_command <- function() {
+  Sys.getenv("ONELAKE_COMMAND", "onelake")
+}
+
+ol_run <- function(args, input = NULL) {
+  output <- system2(ol_command(), args = args, input = input, stdout = TRUE, stderr = TRUE)
+  status <- attr(output, "status")
+  if (!is.null(status) && status != 0) {
+    stop(paste(output, collapse = "\n"), call. = FALSE)
+  }
+  output
+}
+
+ol_connect <- function(workspace, lakehouse) {
+  if (missing(workspace) || !nzchar(workspace)) {
+    stop("workspace is required", call. = FALSE)
+  }
+  if (missing(lakehouse) || !nzchar(lakehouse)) {
+    stop("lakehouse is required", call. = FALSE)
+  }
+  invisible(ol_run(c("connect", workspace, lakehouse)))
+}
+
+ol_status <- function(live = FALSE) {
+  args <- "status"
+  if (isTRUE(live)) {
+    args <- c(args, "--live")
+  }
+  ol_run(args)
+}
+
+ol_ls <- function(path = "/") {
+  ol_run(c("ls", path))
+}
+
+ol_read_text <- function(path) {
+  paste(ol_run(c("cat", path)), collapse = "\n")
+}
+
+ol_write_text <- function(path, text) {
+  invisible(ol_run(c("write", path), input = text))
+}
+
+ol_download <- function(path, local_path) {
+  invisible(ol_run(c("get", path, local_path)))
+}
+
+ol_upload <- function(local_path, path) {
+  invisible(ol_run(c("put", local_path, path)))
+}

--- a/images/mid/onelake/onelake.py
+++ b/images/mid/onelake/onelake.py
@@ -1,0 +1,219 @@
+"""Small OneLake API for Zone Kubeflow notebook containers.
+
+Wraps the Azure Data Lake SDK so notebook users can list, read, write,
+upload, and download OneLake files without learning Microsoft auth. All
+access uses the signed-in user's delegated permissions: tokens come from the
+in-cluster AuthService via the shared ``zone_token_broker`` helper (installed
+in the mid image). Only the workspace/lakehouse selection is persisted; tokens
+live in memory and are re-requested after a restart.
+"""
+
+import os
+import re
+import json
+from pathlib import Path
+
+import zone_token_broker
+
+STORAGE_SCOPE = "https://storage.azure.com/.default"
+ONELAKE_REGION = os.environ.get("ONELAKE_REGION", "canadacentral")
+ONELAKE_ENDPOINT = f"https://{ONELAKE_REGION}-onelake.dfs.fabric.microsoft.com"
+CONFIG_FILE = Path(os.environ.get("ONELAKE_CONFIG", str(Path.home() / ".onelake" / "config.json")))
+MANAGED_ROOTS = ("Files", "Tables")
+
+_client = None
+_fs_client = None
+_config_cache = None
+
+
+def _is_guid(value):
+    return bool(re.match(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+        str(value or ""),
+        re.IGNORECASE,
+    ))
+
+
+def _read_saved_config():
+    global _config_cache
+    if _config_cache is None:
+        try:
+            _config_cache = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            _config_cache = {}
+    return _config_cache
+
+
+def _get_config():
+    saved = _read_saved_config()
+    return (
+        os.environ.get("ONELAKE_WORKSPACE") or saved.get("workspace", ""),
+        os.environ.get("ONELAKE_LAKEHOUSE") or saved.get("lakehouse", ""),
+    )
+
+
+def connect(workspace, lakehouse):
+    """Save the workspace/lakehouse to config, mirror them into the process
+    environment, and reset cached clients so the new selection takes effect."""
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(
+        json.dumps({"workspace": workspace, "lakehouse": lakehouse}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.environ["ONELAKE_WORKSPACE"] = workspace
+    os.environ["ONELAKE_LAKEHOUSE"] = lakehouse
+    reset_clients()
+
+
+def reset_clients():
+    global _client, _fs_client, _config_cache
+    _client = None
+    _fs_client = None
+    _config_cache = None
+
+
+def _lakehouse_prefix(lakehouse=None):
+    if not lakehouse:
+        _, lakehouse = _get_config()
+    if not lakehouse:
+        raise RuntimeError("ONELAKE_LAKEHOUSE is not set")
+    return lakehouse if _is_guid(lakehouse) else f"{lakehouse}.Lakehouse"
+
+
+def _normalize_path(path="/"):
+    path = str(path or "")
+    if path.startswith("onelake://"):
+        path = path[len("onelake://"):]
+    path = path.replace("\\", "/").strip("/")
+    if not path:
+        return ""
+    first, _, rest = path.partition("/")
+    if first in MANAGED_ROOTS:
+        return first if not rest else f"{first}/{rest.strip('/')}"
+    return f"Files/{path}"
+
+
+def _require_file_path(path):
+    normalized = _normalize_path(path)
+    if not normalized or normalized in MANAGED_ROOTS:
+        raise RuntimeError("OneLake writes must target a file inside Files/ or Tables/")
+    return normalized
+
+
+def _build_path(path, lakehouse=None):
+    normalized = _normalize_path(path)
+    if not normalized:
+        raise RuntimeError("OneLake root is synthetic and has no DFS path")
+    return f"{_lakehouse_prefix(lakehouse)}/{normalized}"
+
+
+def _strip_prefix(name, lakehouse=None):
+    prefix = f"{_lakehouse_prefix(lakehouse)}/"
+    return name[len(prefix):] if name.startswith(prefix) else name
+
+
+def _get_service_client():
+    global _client
+    if _client is None:
+        from azure.storage.filedatalake import DataLakeServiceClient
+
+        _client = DataLakeServiceClient(
+            account_url=os.environ.get("ONELAKE_ENDPOINT", ONELAKE_ENDPOINT),
+            credential=zone_token_broker.credential(STORAGE_SCOPE),
+            retry_total=4,
+            retry_backoff_factor=0.5,
+        )
+    return _client
+
+
+def _get_fs_client():
+    global _fs_client
+    if _fs_client is None:
+        workspace, _lakehouse = _get_config()
+        if not workspace:
+            raise RuntimeError("ONELAKE_WORKSPACE is not set")
+        _fs_client = _get_service_client().get_file_system_client(file_system=workspace)
+    return _fs_client
+
+
+def _get_file_client(path):
+    return _get_fs_client().get_file_client(_build_path(_require_file_path(path)))
+
+
+def _read_range(path, start=0, length=None):
+    return _get_file_client(path).download_file(offset=start, length=length).readall()
+
+
+def status(live=False):
+    """Return non-secret OneLake readiness state."""
+    workspace, lakehouse = _get_config()
+    missing = []
+    if not workspace:
+        missing.append("ONELAKE_WORKSPACE or saved workspace")
+    if not lakehouse:
+        missing.append("ONELAKE_LAKEHOUSE or saved lakehouse")
+
+    current = {
+        "workspace": workspace,
+        "lakehouse": lakehouse,
+        "endpoint": os.environ.get("ONELAKE_ENDPOINT", ONELAKE_ENDPOINT),
+        "broker_url": os.environ.get("AUTHSERVICE_BROKER_URL", zone_token_broker.DEFAULT_BROKER_URL),
+        "missing": missing,
+        "ready": not missing,
+    }
+    if live:
+        if not current["ready"]:
+            current["live"] = {"ok": False, "detail": "missing workspace/lakehouse configuration"}
+        else:
+            try:
+                entries = ls("Files")
+                current["live"] = {"ok": True, "detail": f"{len(entries)} entries under Files"}
+            except Exception as error:
+                current["live"] = {"ok": False, "detail": f"{error.__class__.__name__}: {error}"}
+    return current
+
+
+def ls(path="/"):
+    """List OneLake files and directories."""
+    normalized = _normalize_path(path)
+    if not normalized:
+        return [
+            {"name": "Files", "is_directory": True, "size": 0},
+            {"name": "Tables", "is_directory": True, "size": 0},
+        ]
+
+    results = []
+    for item in _get_fs_client().get_paths(path=_build_path(normalized), recursive=False):
+        results.append({
+            "name": _strip_prefix(item.name).rstrip("/"),
+            "is_directory": bool(item.is_directory),
+            "size": getattr(item, "content_length", 0) or 0,
+        })
+    return results
+
+
+def read(path, text=False):
+    """Read a OneLake file as bytes or text."""
+    data = _get_file_client(path).download_file().readall()
+    return data.decode("utf-8") if text else data
+
+
+def write(path, data):
+    """Overwrite a OneLake file with bytes or text."""
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    _get_file_client(path).upload_data(data, overwrite=True)
+
+
+def download(path, local_path):
+    """Download a OneLake file to local disk."""
+    local = Path(local_path)
+    local.parent.mkdir(parents=True, exist_ok=True)
+    with local.open("wb") as handle:
+        _get_file_client(path).download_file().readinto(handle)
+
+
+def upload(local_path, path):
+    """Upload a local file to OneLake."""
+    with Path(local_path).open("rb") as handle:
+        _get_file_client(path).upload_data(handle, overwrite=True)

--- a/images/mid/onelake/onelake_cli.py
+++ b/images/mid/onelake/onelake_cli.py
@@ -1,0 +1,105 @@
+"""Command line interface for OneLake access."""
+
+import argparse
+import sys
+
+import onelake
+
+
+def _cmd_status(args):
+    current = onelake.status(live=args.live)
+    state = "ready" if current["ready"] else "not ready"
+    print(f"OneLake status: {state}")
+    print(f"Workspace: {current['workspace'] or 'N/A'}")
+    print(f"Lakehouse: {current['lakehouse'] or 'N/A'}")
+    print(f"Endpoint: {current['endpoint']}")
+    print(f"Broker: {current['broker_url']}")
+    print("Token storage: in-memory only; re-requested from AuthService after restart")
+    if current["missing"]:
+        print(f"Missing: {', '.join(current['missing'])}")
+    if args.live:
+        live = current.get("live", {"ok": False, "detail": "not checked"})
+        print(f"Live: {'OK' if live['ok'] else 'FAILED'} - {live['detail']}")
+        return 0 if current["ready"] and live["ok"] else 1
+    return 0 if current["ready"] else 1
+
+
+def _cmd_connect(args):
+    onelake.connect(args.workspace, args.lakehouse)
+    print("OneLake configuration saved.")
+    return 0
+
+
+def _cmd_ls(args):
+    for entry in onelake.ls(args.path):
+        kind = "DIR " if entry["is_directory"] else "FILE"
+        print(f"{kind} {entry['size']:>10} {entry['name']}")
+    return 0
+
+
+def _cmd_cat(args):
+    sys.stdout.buffer.write(onelake.read(args.path))
+    return 0
+
+
+def _cmd_write(args):
+    onelake.write(args.path, sys.stdin.buffer.read())
+    return 0
+
+
+def _cmd_get(args):
+    onelake.download(args.remote_path, args.local_path)
+    return 0
+
+
+def _cmd_put(args):
+    onelake.upload(args.local_path, args.remote_path)
+    return 0
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="onelake")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status = subparsers.add_parser("status")
+    status.add_argument("--live", action="store_true", help="attempt a live OneLake Files listing")
+    status.set_defaults(func=_cmd_status)
+
+    connect = subparsers.add_parser("connect")
+    connect.add_argument("workspace")
+    connect.add_argument("lakehouse")
+    connect.set_defaults(func=_cmd_connect)
+
+    list_parser = subparsers.add_parser("ls")
+    list_parser.add_argument("path", nargs="?", default="/")
+    list_parser.set_defaults(func=_cmd_ls)
+
+    cat = subparsers.add_parser("cat")
+    cat.add_argument("path")
+    cat.set_defaults(func=_cmd_cat)
+
+    write = subparsers.add_parser("write")
+    write.add_argument("path")
+    write.set_defaults(func=_cmd_write)
+
+    get = subparsers.add_parser("get")
+    get.add_argument("remote_path")
+    get.add_argument("local_path")
+    get.set_defaults(func=_cmd_get)
+
+    put = subparsers.add_parser("put")
+    put.add_argument("local_path")
+    put.add_argument("remote_path")
+    put.set_defaults(func=_cmd_put)
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/images/mid/onelake/onelake_fsspec.py
+++ b/images/mid/onelake/onelake_fsspec.py
@@ -1,0 +1,155 @@
+"""fsspec backend used by jupyter-fs to show OneLake in JupyterLab.
+
+This is what turns OneLake into a clickable drive in the JupyterLab file
+browser (the "OneLake" entry). It is also the foundation for the planned
+folder-shortcut GUI: browse, open, edit, and save files by clicking, with no
+CLI required. All real work is delegated to the onelake module.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from azure.core.exceptions import ResourceNotFoundError
+from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
+
+import onelake
+
+
+_MARKER = "_ONELAKE_NOT_CONFIGURED.txt"
+_MARKER_TEXT = (
+    "OneLake is not configured for this notebook yet.\n\n"
+    "Set ONELAKE_WORKSPACE and ONELAKE_LAKEHOUSE, or run "
+    "onelake connect <workspace> <lakehouse>.\n"
+)
+
+
+def _clean(path):
+    return str(path or "").replace("\\", "/").strip("/")
+
+
+def _now():
+    return datetime.now(timezone.utc).timestamp()
+
+
+class OneLakeFile(AbstractBufferedFile):
+    def _fetch_range(self, start, end):
+        return onelake._read_range(self.path, start=start, length=end - start)
+
+    def _upload_chunk(self, final=False):
+        if not final:
+            return False
+        self.buffer.seek(0)
+        onelake.write(self.path, self.buffer.read())
+        return True
+
+
+class OneLakeFileSystem(AbstractFileSystem):
+    protocol = "onelake"
+    root_marker = "/"
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        path = str(path or "")
+        if path.startswith("onelake://"):
+            path = path[len("onelake://"):]
+        return "/" + _clean(path) if _clean(path) else "/"
+
+    def _configured(self):
+        return onelake.status()["ready"]
+
+    def _marker_info(self):
+        return {
+            "name": _MARKER,
+            "type": "file",
+            "size": len(_MARKER_TEXT.encode("utf-8")),
+            "created": _now(),
+            "mtime": _now(),
+        }
+
+    def ls(self, path, detail=True, **_kwargs):
+        path = _clean(self._strip_protocol(path))
+        if not self._configured():
+            entries = [self._marker_info()] if path == "" else []
+            return entries if detail else [entry["name"] for entry in entries]
+
+        entries = []
+        for item in onelake.ls(path):
+            entries.append({
+                "name": item["name"].rstrip("/"),
+                "type": "directory" if item["is_directory"] else "file",
+                "size": item["size"],
+                "created": _now(),
+                "mtime": _now(),
+            })
+        return entries if detail else [entry["name"] for entry in entries]
+
+    def info(self, path, **_kwargs):
+        path = _clean(self._strip_protocol(path))
+        if path == "":
+            return {"name": "", "type": "directory", "size": 0, "created": _now(), "mtime": _now()}
+        if not self._configured():
+            if path == _MARKER:
+                return self._marker_info()
+            raise FileNotFoundError(path)
+        if path in onelake.MANAGED_ROOTS:
+            return {"name": path, "type": "directory", "size": 0, "created": _now(), "mtime": _now()}
+
+        try:
+            props = onelake._get_file_client(path).get_file_properties()
+        except ResourceNotFoundError:
+            raise FileNotFoundError(path)
+
+        is_dir = dict(getattr(props, "metadata", None) or {}).get("hdi_isfolder") == "true"
+        return {
+            "name": path,
+            "type": "directory" if is_dir else "file",
+            "size": 0 if is_dir else int(getattr(props, "size", 0) or 0),
+            "created": _now(),
+            "mtime": _now(),
+        }
+
+    def exists(self, path, **_kwargs):
+        try:
+            self.info(path)
+            return True
+        except FileNotFoundError:
+            return False
+
+    # isdir/isfile come from AbstractFileSystem (they call our info()); exists()
+    # is overridden only to surface non-FileNotFound errors instead of hiding them.
+
+    def _open(self, path, mode="rb", block_size=None, **kwargs):
+        path = _clean(self._strip_protocol(path))
+        return OneLakeFile(
+            self,
+            path,
+            mode=mode,
+            block_size=block_size or 5 * 1024 * 1024,
+            **kwargs,
+        )
+
+    def cat_file(self, path, start=None, end=None, **_kwargs):
+        path = _clean(self._strip_protocol(path))
+        if not self._configured() and path == _MARKER:
+            data = _MARKER_TEXT.encode("utf-8")
+        elif start is not None or end is not None:
+            start = start or 0
+            length = None if end is None else end - start
+            return onelake._read_range(path, start=start, length=length)
+        else:
+            data = onelake.read(path)
+        return data[slice(start, end)]
+
+    def cat(self, path, recursive=False, on_error="raise", **kwargs):
+        if recursive:
+            raise NotImplementedError("recursive cat is not supported for OneLake")
+        return self.cat_file(path, **kwargs)
+
+    def pipe_file(self, path, value, **_kwargs):
+        onelake.write(_clean(self._strip_protocol(path)), value)
+
+    def pipe(self, path, value=None, **kwargs):
+        if not isinstance(path, str):
+            raise ValueError("path must be a string")
+        self.pipe_file(path, value, **kwargs)

--- a/images/mid/onelake/onelake_register.py
+++ b/images/mid/onelake/onelake_register.py
@@ -1,0 +1,12 @@
+"""Register the OneLake fsspec implementation."""
+
+try:
+    import fsspec
+
+    fsspec.register_implementation(
+        "onelake",
+        "onelake_fsspec.OneLakeFileSystem",
+        clobber=True,
+    )
+except ImportError:
+    pass


### PR DESCRIPTION
# Description

**What your PR adds/fixes/removes**

Adds a small **OneLake** helper to the `mid` image so notebook users can read, write, list, upload, download, and **browse** OneLake using their own delegated permissions — instead of hand-writing Azure auth + Data Lake SDK code blocks.

Four front doors over one small client (`images/mid/onelake/onelake.py`, ~220 lines):
- `onelake` **CLI** — `status`, `connect`, `ls`, `cat`, `write`, `get`, `put`
- `import onelake` in **Python** (`onelake://…` also works through fsspec, e.g. `pandas.read_csv`)
- `library(onelake)` in **R** — thin wrappers that shell out to the CLI
- a clickable **"OneLake" drive** in the JupyterLab file browser (jupyter-fs + fsspec)

Auth is delegated through the shared `zone_token_broker` already installed in `mid` (#274): a per-user token from the in-cluster AuthService `getPassthroughToken`, kept **in memory only**. This PR ships **no broker of its own**; only the workspace/lakehouse selection is persisted.

It installs via **one self-contained block** in `images/mid/Dockerfile` right after the broker — **no new image layer**, so `docker-bake.hcl` and the CI graph are untouched. The diff is purely additive (11 files under `images/mid/onelake/` + that block). The fsspec drive is the foundation for a future folder-shortcut / click-to-open OneLake GUI.

Reviewer path: `images/mid/onelake/README.md` → `onelake.py` → the `mid/Dockerfile` block. Everything else is thin glue.

# Tests / Quality Checks

CI is green end to end — `base → mid → rstudio → sas-kernel → jupyterlab-cpu → sas` all build and pass their test suites (run [27706934849](https://github.com/StatCan/zone-kubeflow-containers/actions/runs/27706934849): 29 passed, 0 failed). No existing tests were changed. `jupyter-fs` ships as a prebuilt (federated) labextension, so no `jupyter lab build` is needed.

# Beta Process
- [x] Should this branch target "beta"? — **Yes.** It depends on `zone_token_broker`, which lives in `mid` on `beta`.

## Are there breaking changes?
**No — this PR is purely additive** (new files + one Dockerfile block); nothing existing is removed or changed.
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from? — N/A (no breaking change)

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR.
## Automated Testing/build and deployment
- [x] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)? — **Yes.**
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these? — No runtime test added: OneLake calls require the in-cluster AuthService, which CI can't reach. The existing suites pass against the built images.
- [ ] If new features are added that require in-cluster testing ... have you added the `auto-deploy` tag to the PR ... ? — Author action (add `auto-deploy` if you want the dev-cluster image built).

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)? — `jupyter-fs` is a prebuilt extension that auto-enables; please confirm on the dev image.

## VS Code tests

- [ ] Does VS Code open? — Unaffected by this PR.
- [ ] Can you install extensions? — Unaffected by this PR.

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo? — Author action.
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster**? — Author action.
