### PR TITLE
fix: permissions issue on startup with no pvc

### DIFF
--- a/images/rstudio/Dockerfile
+++ b/images/rstudio/Dockerfile
@@ -37,16 +37,16 @@ RUN chmod 755 /opt/jupyter-custom-rstudio-proxy/start_rstudio_server.sh \
 # processes before relaunching from the Jupyter tile.
 COPY --chmod=755 customRStu/rstudio-use-current-conda.sh /usr/local/bin/rstudio-use-current-conda
 
-RUN install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.config/rstudio" \
-    && install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.local/share/rstudio" \
-    && install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.rstudio"
+# RUN install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.config/rstudio" \
+#     && install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.local/share/rstudio" \
+#     && install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.rstudio"
 
-# Seed built-in home defaults for non-PVC starts.
-COPY --chown=${NB_USER}:${NB_GID} customRStu/database.conf ${HOME}/.rstudio/database.conf
-RUN chmod -R g=u \
-    "${HOME}/.config/rstudio" \
-    "${HOME}/.local/share/rstudio" \
-    "${HOME}/.rstudio"
+# # Seed built-in home defaults for non-PVC starts.
+# COPY --chown=${NB_USER}:${NB_GID} customRStu/database.conf ${HOME}/.rstudio/database.conf
+# RUN chmod -R g=u \
+#     "${HOME}/.config/rstudio" \
+#     "${HOME}/.local/share/rstudio" \
+#     "${HOME}/.rstudio"
 
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 

--- a/images/rstudio/Dockerfile
+++ b/images/rstudio/Dockerfile
@@ -37,22 +37,11 @@ RUN chmod 755 /opt/jupyter-custom-rstudio-proxy/start_rstudio_server.sh \
 # processes before relaunching from the Jupyter tile.
 COPY --chmod=755 customRStu/rstudio-use-current-conda.sh /usr/local/bin/rstudio-use-current-conda
 
-# RUN install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.config/rstudio" \
-#     && install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.local/share/rstudio" \
-#     && install -d -o "${NB_USER}" -g "${NB_GID}" -m 0775 "${HOME}/.rstudio"
-
-# # Seed built-in home defaults for non-PVC starts.
-# COPY --chown=${NB_USER}:${NB_GID} customRStu/database.conf ${HOME}/.rstudio/database.conf
-# RUN chmod -R g=u \
-#     "${HOME}/.config/rstudio" \
-#     "${HOME}/.local/share/rstudio" \
-#     "${HOME}/.rstudio"
-
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 
 USER $NB_USER
 
-# Seed first-boot home defaults for PVC-backed starts.
+# Seed first-boot home defaults
 RUN install -d -m 0775 \
     "${HOME_TMP}/.config/rstudio" \
     "${HOME_TMP}/.local/share/rstudio" \


### PR DESCRIPTION
# Description

fixes https://jirab.statcan.ca/browse/ZONE-477

# Tests / Quality Checks


# Beta Process
- [ ] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
