### PR TITLE
chore: remove Conda channels from startup

### DIFF
--- a/images/mid/s6/cont-init.d/02-start-custom
+++ b/images/mid/s6/cont-init.d/02-start-custom
@@ -27,8 +27,6 @@ serviceaccountname=`kubectl get secret artifactory-creds -n $NB_NAMESPACE --temp
 serviceaccounttoken=`kubectl get secret artifactory-creds -n $NB_NAMESPACE --template={{.data.Token}} | base64 --decode`
 # Point conda to Artifactory repository
 conda config --add channels https://$serviceaccountname:$serviceaccounttoken@artifactory.cloud.statcan.ca/artifactory/conda-forge-remote/
-conda config --add channels https://$serviceaccountname:$serviceaccounttoken@artifactory.cloud.statcan.ca/artifactory/conda-pytorch-remote/
-conda config --add channels https://$serviceaccountname:$serviceaccounttoken@artifactory.cloud.statcan.ca/artifactory/conda-nvidia-remote/
 conda config --remove channels 'defaults'
 conda config --remove channels conda-forge --system
 


### PR DESCRIPTION
- The conda channel `conda-pytorch-remote` has been removed.
- The conda channel `conda-nvidia-remote` has been removed.