### PR TITLE
feat: add async zone token broker credential

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -107,8 +107,11 @@ RUN mamba install --quiet --yes -c conda-forge \
 # Installed here in mid, after the mamba install, so it targets the final conda
 # env and leaves source/wheel artifacts under /opt/zone-token-broker for
 # user-created Python and R environments. httr is provided by conda-forge.
+# adlfs provides the fsspec adapter for pandas/read_csv("az://...") workflows
+# that pass zone_token_broker.async_credential(...).
 COPY zone-token-broker /opt/zone-token-broker
 RUN set -eux; \
+    pip install --no-cache-dir 'adlfs==2026.5.0'; \
     pip install --no-cache-dir --no-build-isolation /opt/zone-token-broker; \
     pip wheel --no-cache-dir --no-deps --no-build-isolation --wheel-dir /opt/zone-token-broker/dist /opt/zone-token-broker; \
     /opt/conda/bin/R CMD INSTALL /opt/zone-token-broker/zone-token-broker-r; \

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -100,22 +100,20 @@ RUN mamba install --quiet --yes -c conda-forge \
     && rm -rf /root/.cache /root/.npm \
     && fix-permissions $CONDA_DIR
 
-# Zone AuthService delegated-token helper — Python module + R wrapper.
+# Zone AuthService delegated-token helper — Python package + R wrapper.
 # Provides `import zone_token_broker` in Python and `library(zonetokenbroker)`
 # in R for any downstream consumer (OneLake DFS, Fabric REST, etc.) that needs
 # to call the in-cluster AuthService getPassthroughToken endpoint.
 # Installed here in mid, after the mamba install, so it targets the final conda
-# env: the Python site-packages and the pinned r-base=4.5.1 R library. httr is
-# provided by conda-forge (r-httr, in the mamba list above).
-COPY zone-token-broker /tmp/zone-token-broker
+# env and leaves source/wheel artifacts under /opt/zone-token-broker for
+# user-created Python and R environments. httr is provided by conda-forge.
+COPY zone-token-broker /opt/zone-token-broker
 RUN set -eux; \
-    pip install --no-cache-dir 'requests'; \
-    purelib="$(/opt/conda/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
-    install -d "$purelib"; \
-    install -m 0644 /tmp/zone-token-broker/zone_token_broker.py "$purelib/zone_token_broker.py"; \
-    /opt/conda/bin/R CMD INSTALL /tmp/zone-token-broker/zone-token-broker-r; \
-    rm -rf /tmp/zone-token-broker; \
-    fix-permissions "${CONDA_DIR}"
+    pip install --no-cache-dir --no-build-isolation /opt/zone-token-broker; \
+    pip wheel --no-cache-dir --no-deps --no-build-isolation --wheel-dir /opt/zone-token-broker/dist /opt/zone-token-broker; \
+    /opt/conda/bin/R CMD INSTALL /opt/zone-token-broker/zone-token-broker-r; \
+    fix-permissions "${CONDA_DIR}"; \
+    fix-permissions /opt/zone-token-broker
 
 # Install DuckDB extensions for parquet visualizer (air-gapped support)
 COPY --chown=${NB_USER}:${NB_GID} .duckdbrc ${HOME_TMP}/.duckdbrc

--- a/images/mid/zone-token-broker/pyproject.toml
+++ b/images/mid/zone-token-broker/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zone-token-broker"
+version = "0.1.0"
+description = "Internal AuthService client for delegated access tokens."
+requires-python = ">=3.9"
+dependencies = ["requests"]
+
+[tool.setuptools]
+py-modules = ["zone_token_broker"]

--- a/images/mid/zone-token-broker/zone_token_broker.py
+++ b/images/mid/zone-token-broker/zone_token_broker.py
@@ -1,5 +1,6 @@
 """Internal AuthService client for delegated access tokens."""
 
+import asyncio
 import json
 import os
 import re
@@ -124,6 +125,25 @@ class BrokerCredential:
         return AccessToken(token.access_token, token.expires_on)
 
 
+class AsyncBrokerCredential:
+    """Async Azure TokenCredential backed by AuthService for adlfs/fsspec."""
+
+    def __init__(self, scope, client=None):
+        self.scope = scope
+        self.client = client or BrokerClient()
+
+    async def get_token(self, *scopes, **_kwargs):
+        scope = " ".join(scopes) if scopes else self.scope
+        token = await asyncio.to_thread(self.client.get_token, scope)
+        return AccessToken(token.access_token, token.expires_on)
+
+    async def close(self):
+        session = getattr(self.client, "_session", None)
+        if session is not None:
+            session.close()
+            self.client._session = None
+
+
 _default_client = BrokerClient()
 
 
@@ -133,3 +153,7 @@ def get_token(scope):
 
 def credential(scope):
     return BrokerCredential(scope=scope)
+
+
+def async_credential(scope):
+    return AsyncBrokerCredential(scope=scope)

--- a/tests/general/test_zone_token_broker.py
+++ b/tests/general/test_zone_token_broker.py
@@ -33,6 +33,8 @@ def test_zone_token_broker_package_imports(container):
             "assert metadata.version('zone-token-broker') == '0.1.0'; "
             "assert ztb.DEFAULT_TOKEN_PATH == '/authservice/getPassthroughToken'; "
             "assert ztb.credential('https://storage.azure.com/.default').scope == "
+            "'https://storage.azure.com/.default'; "
+            "assert ztb.async_credential('https://storage.azure.com/.default').scope == "
             "'https://storage.azure.com/.default'"
         ),
     ])
@@ -57,10 +59,31 @@ python -m venv /tmp/zone-token-broker-venv
 /tmp/zone-token-broker-venv/bin/python -m pip install --no-deps "$wheel"
 /tmp/zone-token-broker-venv/bin/python - <<'PY'
 import importlib.metadata as metadata
+import asyncio
 import zone_token_broker as ztb
 
 assert metadata.version("zone-token-broker") == "0.1.0"
 assert ztb.BrokerClient(broker_url="http://example.test").broker_url == "http://example.test"
+
+class FakeClient:
+    def __init__(self):
+        self.scopes = []
+
+    def get_token(self, scope):
+        self.scopes.append(scope)
+        return ztb.BrokerToken("token-a", 123)
+
+async def main():
+    client = FakeClient()
+    credential = ztb.AsyncBrokerCredential("scope-a", client=client)
+    token = await credential.get_token()
+    assert token.token == "token-a"
+    assert token.expires_on == 123
+    await credential.get_token("scope-b")
+    assert client.scopes == ["scope-a", "scope-b"]
+    await credential.close()
+
+asyncio.run(main())
 PY
 """,
     ])

--- a/tests/general/test_zone_token_broker.py
+++ b/tests/general/test_zone_token_broker.py
@@ -29,6 +29,7 @@ def test_zone_token_broker_package_imports(container):
         "-c",
         (
             "import importlib.metadata as metadata; "
+            "import adlfs; "
             "import zone_token_broker as ztb; "
             "assert metadata.version('zone-token-broker') == '0.1.0'; "
             "assert ztb.DEFAULT_TOKEN_PATH == '/authservice/getPassthroughToken'; "

--- a/tests/general/test_zone_token_broker.py
+++ b/tests/general/test_zone_token_broker.py
@@ -1,0 +1,91 @@
+import pytest
+
+from tests.general.wait_utils import wait_for_exec_success
+
+
+def _skip_if_base_image(image_name):
+    image_name = image_name.lower()
+    if "/base:" in image_name or image_name.endswith("/base") or "base:" in image_name.split("/")[-1]:
+        pytest.skip("zone_token_broker is installed from the mid image onward")
+
+
+@pytest.mark.integration
+def test_zone_token_broker_package_imports(container):
+    _skip_if_base_image(container.image_name)
+    container.run()
+
+    success, output = wait_for_exec_success(
+        container=container,
+        command=["python", "--version"],
+        timeout=30,
+        initial_delay=0.5,
+        max_delay=3.0,
+    )
+    if not success:
+        raise AssertionError(f"Container failed to be ready for execution within timeout. Output: {output}")
+
+    result = container.container.exec_run([
+        "python",
+        "-c",
+        (
+            "import importlib.metadata as metadata; "
+            "import zone_token_broker as ztb; "
+            "assert metadata.version('zone-token-broker') == '0.1.0'; "
+            "assert ztb.DEFAULT_TOKEN_PATH == '/authservice/getPassthroughToken'; "
+            "assert ztb.credential('https://storage.azure.com/.default').scope == "
+            "'https://storage.azure.com/.default'"
+        ),
+    ])
+
+    assert result.exit_code == 0, result.output.decode("utf-8")
+
+
+@pytest.mark.integration
+def test_zone_token_broker_can_install_into_new_venv(container):
+    _skip_if_base_image(container.image_name)
+    container.run()
+
+    result = container.container.exec_run([
+        "sh",
+        "-c",
+        """
+set -eu
+test -f /opt/zone-token-broker/pyproject.toml
+wheel="$(ls /opt/zone-token-broker/dist/zone_token_broker-*.whl | head -n 1)"
+test -f "$wheel"
+python -m venv /tmp/zone-token-broker-venv
+/tmp/zone-token-broker-venv/bin/python -m pip install --no-deps "$wheel"
+/tmp/zone-token-broker-venv/bin/python - <<'PY'
+import importlib.metadata as metadata
+import zone_token_broker as ztb
+
+assert metadata.version("zone-token-broker") == "0.1.0"
+assert ztb.BrokerClient(broker_url="http://example.test").broker_url == "http://example.test"
+PY
+""",
+    ])
+
+    assert result.exit_code == 0, result.output.decode("utf-8")
+
+
+@pytest.mark.integration
+def test_zone_token_broker_r_package_can_install_into_user_library(container):
+    _skip_if_base_image(container.image_name)
+    container.run()
+
+    result = container.container.exec_run([
+        "R",
+        "--slave",
+        "-e",
+        (
+            "src <- '/opt/zone-token-broker/zone-token-broker-r'; "
+            "stopifnot(file.exists(file.path(src, 'DESCRIPTION'))); "
+            "lib <- tempfile('ztb-r-lib-'); "
+            "dir.create(lib); "
+            "install.packages(src, lib = lib, repos = NULL, type = 'source'); "
+            "library(zonetokenbroker, lib.loc = lib); "
+            "stopifnot(exists('zone_get_token'))"
+        ),
+    ])
+
+    assert result.exit_code == 0, result.output.decode("utf-8")


### PR DESCRIPTION
## Summary
- Adds `AsyncBrokerCredential` and `async_credential(scope)` for adlfs/fsspec workflows that expect an async Azure credential.
- Keeps the existing sync `credential(scope)` API unchanged for normal Azure SDK clients.
- Includes the package-install baseline from #276 because `beta` does not yet contain the installable broker wheel/source layout.
- Extends broker smoke tests to cover the async credential wrapper without making live AuthService calls in CI.

## User test snippet

```python
import pandas as pd
import zone_token_broker as ztb

CONTAINER_NAME = "pae-eap-projects-projets"
STORAGE_ACCOUNT_NAME = "stpdlincaesa"
TEST_CSV_PATH = "DST/io_helpers/test.csv"

storage_options = {
    "account_name": STORAGE_ACCOUNT_NAME,
    "anon": False,
    "credential": ztb.async_credential("https://storage.azure.com/.default"),
}

df = pd.read_csv(
    f"az://{CONTAINER_NAME}/{TEST_CSV_PATH}",
    storage_options=storage_options,
)
print(df.head())
```

If this still times out, first isolate broker/network reachability from fsspec:

```python
import time
import zone_token_broker as ztb

t0 = time.time()
token = ztb.get_token("https://storage.azure.com/.default")
print("got token in", time.time() - t0, "seconds")
print(token.expires_on)
```

## Test plan
- [x] `git diff --check`
- [x] `python3 -m py_compile images/mid/zone-token-broker/zone_token_broker.py tests/general/test_zone_token_broker.py`
- [x] Direct async credential smoke test with a fake broker client.
- [x] Build/install wheel into a disposable venv and run async credential smoke test from the installed package.
- [x] Disposable venv with `requirements-dev.txt`: `pytest --collect-only tests/general/test_zone_token_broker.py -q` collects 3 tests.
- [ ] Built image integration tests in GitHub Actions.

## Notes
This does not change the AuthService endpoint, request parameters, or token parsing. It only adds an async credential shape around the existing broker client so adlfs/fsspec can call it like `AzureCliCredential` from `azure.identity.aio`.
