### PR TITLE
feat: add zone_openai broker-backed Azure OpenAI helper

### DIFF
--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -103,16 +103,18 @@ RUN mamba install --quiet --yes -c conda-forge \
 # Zone AuthService delegated-token helper — Python module + R wrapper.
 # Provides `import zone_token_broker` in Python and `library(zonetokenbroker)`
 # in R for any downstream consumer (OneLake DFS, Fabric REST, etc.) that needs
-# to call the in-cluster AuthService getPassthroughToken endpoint.
+# to call the in-cluster AuthService getPassthroughToken endpoint, and
+# `import zone_openai` for broker-authenticated Azure OpenAI clients.
 # Installed here in mid, after the mamba install, so it targets the final conda
 # env: the Python site-packages and the pinned r-base=4.5.1 R library. httr is
 # provided by conda-forge (r-httr, in the mamba list above).
 COPY zone-token-broker /tmp/zone-token-broker
 RUN set -eux; \
-    pip install --no-cache-dir 'requests'; \
+    pip install --no-cache-dir 'requests' 'openai'; \
     purelib="$(/opt/conda/bin/python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
     install -d "$purelib"; \
     install -m 0644 /tmp/zone-token-broker/zone_token_broker.py "$purelib/zone_token_broker.py"; \
+    install -m 0644 /tmp/zone-token-broker/zone_openai.py "$purelib/zone_openai.py"; \
     /opt/conda/bin/R CMD INSTALL /tmp/zone-token-broker/zone-token-broker-r; \
     rm -rf /tmp/zone-token-broker; \
     fix-permissions "${CONDA_DIR}"

--- a/images/mid/zone-token-broker/zone_openai.py
+++ b/images/mid/zone-token-broker/zone_openai.py
@@ -1,0 +1,87 @@
+"""Broker-backed Azure OpenAI client helpers.
+
+On-platform, tokens come from AuthService via zone_token_broker (delegated
+per-user identity, no API keys). For local development the helpers fall back
+to azure-identity (`az login`) or an AZURE_OPENAI_API_KEY environment
+variable.
+"""
+
+import os
+
+from zone_token_broker import BrokerCredential, TokenBrokerError
+
+COGNITIVE_SERVICES_SCOPE = "https://cognitiveservices.azure.com/.default"
+
+ENDPOINT_ENV = "AZURE_OPENAI_ENDPOINT"
+API_KEY_ENV = "AZURE_OPENAI_API_KEY"
+API_VERSION_ENV = "AZURE_OPENAI_API_VERSION"
+DEFAULT_API_VERSION = "2024-10-21"
+
+
+class ZoneOpenAIError(RuntimeError):
+    """Raised when an Azure OpenAI client cannot be configured."""
+
+
+def token_provider(scope=COGNITIVE_SERVICES_SCOPE):
+    """Return a zero-argument callable yielding a bearer token for `scope`.
+
+    Tries the AuthService broker first; if it is unreachable (e.g. running
+    outside the cluster) falls back to azure.identity.DefaultAzureCredential,
+    which picks up `az login`, environment, or managed identity.
+    """
+    broker = BrokerCredential(scope=scope)
+    fallback = {}
+
+    def _fallback_credential():
+        if "credential" not in fallback:
+            try:
+                from azure.identity import DefaultAzureCredential
+            except ImportError as error:
+                raise ZoneOpenAIError(
+                    "Token broker is unavailable and azure-identity is not "
+                    "installed for local fallback (pip install azure-identity)"
+                ) from error
+            fallback["credential"] = DefaultAzureCredential()
+        return fallback["credential"]
+
+    def _get_token():
+        try:
+            return broker.get_token(scope).token
+        except Exception as broker_error:
+            try:
+                return _fallback_credential().get_token(scope).token
+            except ZoneOpenAIError:
+                raise
+            except Exception as error:
+                raise ZoneOpenAIError(
+                    f"Could not get an Azure OpenAI token from the broker "
+                    f"({broker_error}) or local credentials ({error})"
+                ) from error
+
+    return _get_token
+
+
+def client(deployment=None, endpoint=None, api_version=None, scope=COGNITIVE_SERVICES_SCOPE, **kwargs):
+    """Return a preauthenticated openai.AzureOpenAI client.
+
+    Credential precedence: AZURE_OPENAI_API_KEY if set, otherwise Entra ID
+    tokens (broker on-platform, `az login` locally).
+    """
+    try:
+        from openai import AzureOpenAI
+    except ImportError as error:
+        raise ZoneOpenAIError("The openai package is required (pip install openai)") from error
+
+    endpoint = endpoint or os.environ.get(ENDPOINT_ENV)
+    if not endpoint:
+        raise ZoneOpenAIError(f"Set {ENDPOINT_ENV} or pass endpoint= (https://<resource>.openai.azure.com)")
+    api_version = api_version or os.environ.get(API_VERSION_ENV, DEFAULT_API_VERSION)
+
+    options = dict(azure_endpoint=endpoint, api_version=api_version, **kwargs)
+    if deployment:
+        options["azure_deployment"] = deployment
+
+    api_key = os.environ.get(API_KEY_ENV)
+    if api_key:
+        return AzureOpenAI(api_key=api_key, **options)
+    return AzureOpenAI(azure_ad_token_provider=token_provider(scope), **options)


### PR DESCRIPTION
## What

Adds a `zone_openai` module to the zone-token-broker layer in the mid image, giving notebook users a one-line preauthenticated Azure OpenAI client:

```python
import zone_openai
client = zone_openai.client(deployment="gpt-5-mini")
```

## How it authenticates

- **On-platform:** Entra ID tokens come from AuthService via the existing `zone_token_broker` credential (scope `https://cognitiveservices.azure.com/.default`) — delegated per-user identity, no API keys in code or env, same pattern as the OneLake/DVC consumers.
- **Local development:** falls back to `azure.identity.DefaultAzureCredential` (`az login`) if the broker is unreachable, or `AZURE_OPENAI_API_KEY` if set.

## Image changes

- Installs `zone_openai.py` into site-packages alongside `zone_token_broker.py`.
- Adds the `openai` pip package to the mid image so the helper works out of the box (`azure-identity` is intentionally not added — it is only needed for the local-dev fallback, never in-cluster).

## Validation

Tested end-to-end against a live Azure OpenAI `gpt-5-mini` deployment: client construction, chat completions, and tool-calling all work through the Entra ID token path with no API key present. The broker-first/fallback ordering was exercised both with the broker unreachable (falls back cleanly) and with `AZURE_OPENAI_API_KEY` set (takes precedence).

## Platform prerequisite (not in this PR)

For the on-platform path, AuthService's app registration needs the Cognitive Services scope granted, and an Azure OpenAI deployment must exist in the tenant. The module degrades with clear error messages until then.