### PR TITLE
feat: browser-less az login via managed-identity shim over the token broker

### DIFF
--- a/docs/zone-msi-login.md
+++ b/docs/zone-msi-login.md
@@ -1,0 +1,194 @@
+# Zone managed-identity login (zone-msi-shim)
+
+*Engineering and security notes for browserless Azure sign-in in Zone
+notebook pods. User-facing doc: [`images/mid/azure-sign-in.md`](../images/mid/azure-sign-in.md).
+Broker client code: [`images/mid/zone-token-broker/`](../images/mid/zone-token-broker/).*
+
+## Summary
+
+Zone notebook pods obtain **user-delegated** Azure access tokens with no
+browser and no device code. The user's real Entra sign-in already happened
+in their desktop browser when they logged into zone.statcan.ca (Kubeflow
+AuthService / OIDC). StatCan's AuthService fork exposes
+`getPassthroughToken?scope=X` in-cluster, which performs an Entra
+**on-behalf-of (OBO)** exchange and returns a delegated access token for the
+pod's user — this is the existing `zone-token-broker` package.
+
+New in this change: a localhost shim (**zone-msi-shim**, `127.0.0.1:8901`)
+speaks the Azure App Service managed-identity protocol and translates
+managed-identity token requests (`resource=X`) into broker calls
+(`scope=X/.default`). The result:
+
+- `az login --identity` just works.
+- Python `DefaultAzureCredential` / `ManagedIdentityCredential` just work.
+- R keeps using the native broker client (`zonetokenbroker::zone_get_token`)
+  because R AzureAuth's managed-identity path pins the IMDS IP
+  (`169.254.169.254`) and ignores `IDENTITY_ENDPOINT` (see below).
+
+## Architecture
+
+```
+Desktop                          Zone cluster                          Entra ID
+───────                          ────────────                         ─────────
+User's browser ──── OIDC ──► zone.statcan.ca ingress
+  (real Entra sign-in,             │
+   MFA, GC SSO)                    ▼
+                          AuthService (StatCan fork)
+                            │  holds user's OIDC session
+                            │
+   User's notebook pod      │
+  ┌────────────────────────┐│
+  │ az / azure-identity /  ││
+  │ any MSI-aware SDK      ││
+  │      │ MSI protocol    ││
+  │      │ (App Service,   ││
+  │      │  2019-08-01)    ││
+  │      ▼                 ││
+  │ zone-msi-shim          ││
+  │ (127.0.0.1:8901) ──────┼┼──► getPassthroughToken?scope=X
+  │                        ││    (caller pod IP → namespace →
+  │ R: zonetokenbroker ────┼┘     namespace owner's session)
+  └────────────────────────┘            │
+                                        │ on-behalf-of exchange
+                                        ▼
+                              Entra token endpoint ──► delegated access
+                                                       token, minted as
+                                                       the user
+```
+
+The pod never contacts `login.microsoftonline.com`, GC SSO, or any
+Microsoft CDN. The only Entra traffic is server-side, from AuthService,
+which already has that connectivity for the OIDC login flow.
+
+## Protocol details
+
+The shim implements the App Service managed-identity protocol
+(api-version `2019-08-01`), which `az`, `azure-identity`, and other MSAL
+based SDKs automatically prefer when both environment variables are set:
+
+```
+IDENTITY_ENDPOINT=http://127.0.0.1:8901/msi/token
+IDENTITY_HEADER=<per-pod random secret>
+```
+
+Request (what the SDKs send):
+
+```
+GET /msi/token?api-version=2019-08-01&resource=https://storage.azure.com
+X-IDENTITY-HEADER: <value of $IDENTITY_HEADER>
+```
+
+Response (App Service shape; `expires_on` is epoch seconds, as a string,
+matching the 2019-08-01 contract):
+
+```json
+{
+  "access_token": "eyJ...",
+  "expires_on": "1767200000",
+  "resource": "https://storage.azure.com",
+  "token_type": "Bearer"
+}
+```
+
+Behavior:
+
+- **resource → scope mapping.** The managed-identity protocol is
+  resource-based (Entra v1 style); the broker is scope-based (v2). The shim
+  maps `resource=X` to `scope=X/.default`, normalizing any trailing slash
+  on the resource first.
+- **Backing call.** Each request becomes a broker call to
+  `http://authservice.kubeflow.svc.cluster.local:8080/authservice/getPassthroughToken?scope=X/.default`
+  (same endpoint and env overrides — `AUTHSERVICE_BROKER_URL`,
+  `AUTHSERVICE_BROKER_TOKEN_PATH` — as the existing Python/R clients).
+  The broker's JSON (`access_token`, `expires_on` epoch seconds) maps
+  directly onto the MSI response.
+- **Requests without the correct `X-IDENTITY-HEADER` are rejected**,
+  matching App Service semantics.
+- **Single identity.** Real MSI endpoints accept `client_id`/`object_id`/
+  `mi_res_id` to select among user-assigned identities. There is exactly
+  one identity here — the signed-in Zone user — so these selectors are
+  accepted and ignored.
+- **Errors** are returned in the MSI error shape so SDK retry/failure
+  behavior is sensible; broker error detail (e.g. AADSTS codes from a
+  failed OBO) is passed through for diagnosability.
+
+### Why R is different
+
+R `AzureAuth`'s managed-identity code path hardcodes the IMDS address
+(`169.254.169.254`) rather than honoring `IDENTITY_ENDPOINT`, so it cannot
+reach a loopback shim. R users therefore call the native broker client
+directly — `zonetokenbroker::zone_get_token(scope)` — which mirrors the
+Python module (same endpoint, env overrides, 30 s timeout, and per-scope
+in-memory caching with a 5-minute expiry buffer).
+
+## Trust boundaries and threat notes
+
+- **Loopback only.** The shim binds `127.0.0.1`; it is not reachable from
+  other pods, and there is no new Service, port, ingress, or NetworkPolicy.
+  `IDENTITY_HEADER` is a per-pod random secret, so even a same-node
+  process outside the pod's network namespace cannot forge requests.
+- **No credentials in the shim.** The shim is a pure protocol translator.
+  It holds no client secret, no refresh token, nothing to exfiltrate. All
+  credential material stays server-side in AuthService.
+- **Broker trust model unchanged.** AuthService identifies the caller by
+  source pod IP, maps it to the owning namespace, and uses that user's
+  stored OIDC session for the OBO exchange. The shim adds no new principal
+  and no new path to anyone else's tokens. As with the broker today, **any
+  process running in the user's pod (or namespace) can obtain that user's
+  delegated tokens** — the pod is inside the user's trust boundary.
+- **Token audience limits.** Every token is audience-bound to the single
+  requested resource and carries only that resource's delegated
+  permissions; the shim cannot mint anything the broker could not already
+  mint.
+- **ARM consent widens scope — flag for Cybersecurity.** Consenting the
+  Azure Service Management permission (below) extends delegated access
+  from data-plane services (Storage, Cognitive Services — already proven)
+  to the **control plane**: an ARM token lets a pod process enumerate and
+  manage whatever Azure resources the *user's own RBAC roles* allow. The
+  blast radius stays bounded by the user's RBAC, but it is a real widening
+  and should be assessed as such.
+- **No new egress.** Unlike browser-based flows, nothing in the pod
+  connects to Microsoft sign-in infrastructure.
+
+## Tenant prerequisite (platform team)
+
+Before `az login --identity` can work, the **Zone AuthService app
+registration** needs the delegated permission
+**Azure Service Management → `user_impersonation`** added and
+**admin-consented** in the tenant. Without it, the OBO exchange for an ARM
+audience fails with a consent-required error (AADSTS65001) and `az login`
+cannot obtain its ARM token. Storage and Cognitive Services scopes are
+already consented and proven end-to-end; ARM is the only net-new consent
+this feature requires. The same process applies to any future scope users
+request: one-time delegated consent on the AuthService app registration.
+
+## Limits
+
+- **User-delegated only.** No app-only tokens, no service principals — a
+  token is always minted *as the signed-in user* with that user's
+  permissions.
+- **Bounded by the Zone session (~24 h).** When the AuthService session
+  expires, token requests fail until the user signs in to zone.statcan.ca
+  again in their desktop browser. No re-login inside the pod is possible
+  or needed.
+- **Single tenant.** Only the StatCan tenant; no guest/multi-tenant use.
+- **No Conditional Access step-up.** If a resource requires an
+  authentication step-up (e.g. a fresh-MFA claims challenge) beyond what
+  the original zone.statcan.ca sign-in satisfied, the OBO exchange cannot
+  provide it.
+- **Pod-level trust.** Any process in the user's pod/namespace can obtain
+  the user's tokens — identical to the existing broker trust model.
+
+## History and rationale
+
+Device-code authentication is being retired because the grant is phishable
+(an attacker-initiated flow can be completed by a victim entering a code in
+their own trusted browser). An in-pod browser was prototyped as the
+replacement (PR #281): a headless Chromium in the pod runs the standard
+interactive authorization-code flow, streamed into a JupyterLab tab. It
+worked end-to-end in the test harness, but the sign-in pages depend on
+egress to GC SSO (`sso1.gcsso.gc.ca`) and Microsoft's sign-in CDNs, which
+pod egress does not reliably allow. The managed-identity shim needs **no
+new egress at all**, because the token exchange happens server-side in
+AuthService — the pod only ever talks to loopback and to the in-cluster
+AuthService endpoint the broker already used.

--- a/images/mid/Dockerfile
+++ b/images/mid/Dockerfile
@@ -118,6 +118,15 @@ RUN set -eux; \
     fix-permissions "${CONDA_DIR}"; \
     fix-permissions /opt/zone-token-broker
 
+# App Service managed-identity emulation: azure-identity and MSAL (so
+# `az login --identity` too) detect these env vars and speak the 2019-08-01
+# protocol to the zone-msi-shim s6 service, which exchanges the requested
+# resource for a user-delegated token via zone_token_broker. IDENTITY_HEADER
+# is a static value on purpose: the shim binds loopback inside a single-user
+# pod, so the header only exists to satisfy the protocol, not to gate access.
+ENV IDENTITY_ENDPOINT=http://127.0.0.1:8901/msi/token \
+    IDENTITY_HEADER=zone
+
 # Install DuckDB extensions for parquet visualizer (air-gapped support)
 COPY --chown=${NB_USER}:${NB_GID} .duckdbrc ${HOME_TMP}/.duckdbrc
 
@@ -204,7 +213,7 @@ RUN set -eu \
     } >> "${HOME_TMP}/.bashrc"
 
 # Copy over various files that should be restored into HOME on first boot.
-COPY --chown=${NB_USER}:${NB_GID} .Rprofile .profile .condarc connect-to-filer.md ${HOME_TMP}/
+COPY --chown=${NB_USER}:${NB_GID} .Rprofile .profile .condarc connect-to-filer.md azure-sign-in.md ${HOME_TMP}/
 COPY --chown=${NB_USER}:${NB_GID} gpg-agent.conf ${HOME_TMP}/.gnupg/gpg-agent.conf
 
 # Set Python interpreter path for VSCode

--- a/images/mid/azure-sign-in.md
+++ b/images/mid/azure-sign-in.md
@@ -1,0 +1,92 @@
+# Signing in to Azure from your workspace
+
+You do not need to sign in to Azure from inside your workspace — you already
+did. Logging into **zone.statcan.ca** is your Azure sign-in. There is no
+browser pop-up, no device code, and nothing to copy-paste. Just use the
+commands below.
+
+## az CLI
+
+One command, no browser, no device code:
+
+```bash
+az login --identity
+```
+
+That's it. `az storage`, `az cognitiveservices`, and friends work as you.
+
+If `az login --identity` complains that you have no subscriptions, add
+`--allow-no-subscriptions` (see Troubleshooting below).
+
+## Python
+
+The standard Azure SDK credentials just work — no configuration needed:
+
+```python
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient
+
+credential = DefaultAzureCredential()
+client = BlobServiceClient(
+    "https://<account>.blob.core.windows.net", credential=credential
+)
+```
+
+Or, if you only need a raw token:
+
+```python
+from azure.identity import ManagedIdentityCredential
+
+credential = ManagedIdentityCredential()
+token = credential.get_token("https://storage.azure.com/.default")
+```
+
+## R
+
+R uses the built-in `zonetokenbroker` package. Ask it for a token for the
+service you want, then pass that token to whatever package you're using:
+
+```r
+token <- zonetokenbroker::zone_get_token("https://storage.azure.com/.default")
+
+# e.g. with AzureStor:
+ep <- AzureStor::storage_endpoint(
+  "https://<account>.dfs.core.windows.net",
+  token = token
+)
+```
+
+Any package or request that accepts a bearer token string works, for example
+with httr:
+
+```r
+httr::GET(url, httr::add_headers(Authorization = paste("Bearer", token)))
+```
+
+Tokens are cached and refreshed for you — call `zone_get_token()` whenever
+you need one; repeated calls are free.
+
+## How it works
+
+Your login to zone.statcan.ca **is** the Azure sign-in — by the time your
+workspace opens, you are already authenticated. When a tool in your
+workspace asks for an Azure token, the Zone platform mints one for you,
+server-side, from that same login session. Nothing in your workspace ever
+talks to a Microsoft sign-in page — no browser, no device code, no password.
+
+## Troubleshooting
+
+**Token errors after about a day.** Your Zone login session has expired.
+Sign in to [zone.statcan.ca](https://zone.statcan.ca) again in your regular
+browser, then retry the command — no need to restart your workspace.
+
+**"Consent required" / "permission or scope not consented" errors.** The
+Azure permission you're asking for hasn't been approved for the Zone yet.
+Contact the platform team with the service you're trying to reach (for
+example the scope from the error message) — they can approve it. This is a
+one-time, platform-wide approval, not something you can fix yourself.
+
+**`az login --identity` reports no subscriptions.** Either run
+`az login --identity --allow-no-subscriptions` (fine if you only need data
+services like Storage), or you don't have a role on any Azure subscription
+yet — ask your project's Azure administrator for access.

--- a/images/mid/s6/services.d/zone-msi/run
+++ b/images/mid/s6/services.d/zone-msi/run
@@ -1,0 +1,12 @@
+#!/command/with-contenv bash
+
+# Managed-identity shim: serves the App Service MSI protocol on loopback so
+# `az login --identity` and DefaultAzureCredential authenticate as the pod
+# user without a browser. The shim only proxies zone_token_broker; when the
+# broker is unreachable it stays up and answers broker_error so credential
+# chains can fall through instead of hanging on a dead endpoint.
+echo "--------------------starting zone-msi-shim--------------------"
+exec 2>&1
+exec \
+  s6-envdir /run/s6-env \
+  /opt/conda/bin/zone-msi-shim

--- a/images/mid/zone-token-broker/pyproject.toml
+++ b/images/mid/zone-token-broker/pyproject.toml
@@ -14,6 +14,7 @@ zone-dvc = ["dvc", "dvc-azure"]
 
 [project.scripts]
 zone-dvc = "zone_dvc:main"
+zone-msi-shim = "zone_msi_shim:main"
 
 [tool.setuptools]
-py-modules = ["zone_token_broker", "zone_dvc"]
+py-modules = ["zone_token_broker", "zone_dvc", "zone_msi_shim"]

--- a/images/mid/zone-token-broker/zone_msi_shim.py
+++ b/images/mid/zone-token-broker/zone_msi_shim.py
@@ -99,8 +99,24 @@ class MsiRequestHandler(BaseHTTPRequestHandler):
         self.log_message("%s %s %s", self.command, urlparse(self.path).path, code)
 
 
+def _port():
+    # Kubernetes injects <SERVICE>_PORT=tcp://<ip>:<port> for every service
+    # in the namespace, so a notebook named zone-msi shadows this variable
+    # with a URL. Anything that is not a plain port number is ignored.
+    raw = os.environ.get(PORT_ENV, "")
+    try:
+        return int(raw)
+    except ValueError:
+        if raw:
+            print(
+                f"zone-msi-shim: ignoring non-numeric {PORT_ENV}={raw!r}; using {DEFAULT_PORT}",
+                file=sys.stderr,
+            )
+        return DEFAULT_PORT
+
+
 def main():
-    port = int(os.environ.get(PORT_ENV, DEFAULT_PORT))
+    port = _port()
     server = ThreadingHTTPServer((BIND_ADDRESS, port), MsiRequestHandler)
     print(f"zone-msi-shim: serving managed-identity tokens on http://{BIND_ADDRESS}:{port}", file=sys.stderr)
     try:

--- a/images/mid/zone-token-broker/zone_msi_shim.py
+++ b/images/mid/zone-token-broker/zone_msi_shim.py
@@ -1,0 +1,116 @@
+"""Localhost App Service managed-identity endpoint backed by the Zone token broker."""
+
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import zone_token_broker
+
+# Loopback only: the shim mints user-delegated tokens, so it must never be
+# reachable from outside the single-user pod.
+BIND_ADDRESS = "127.0.0.1"
+DEFAULT_PORT = 8901
+PORT_ENV = "ZONE_MSI_PORT"
+IDENTITY_HEADER_ENV = "IDENTITY_HEADER"
+
+
+class MsiRequestHandler(BaseHTTPRequestHandler):
+    """Speak the App Service 2019-08-01 managed-identity protocol.
+
+    azure-identity and MSAL (so `az login --identity` too) detect the
+    IDENTITY_ENDPOINT/IDENTITY_HEADER env vars and GET this endpoint with
+    api-version and resource query params plus an X-IDENTITY-HEADER header.
+    Every response is answered from zone_token_broker, which performs the
+    on-behalf-of exchange (and caching) through AuthService.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        self._handle(include_body=True)
+
+    # Probes may HEAD the endpoint; answer with headers only.
+    def do_HEAD(self):
+        self._handle(include_body=False)
+
+    def _handle(self, include_body):
+        expected_header = os.environ.get(IDENTITY_HEADER_ENV)
+        if expected_header and self.headers.get("X-IDENTITY-HEADER") != expected_header:
+            self._send_json(
+                401,
+                {"error": "unauthorized", "error_description": "X-IDENTITY-HEADER mismatch"},
+                include_body,
+            )
+            return
+
+        query = parse_qs(urlparse(self.path).query)
+        resource = (query.get("resource") or [""])[0].strip()
+        if not resource:
+            self._send_json(
+                400,
+                {"error": "invalid_request", "error_description": "resource query parameter is required"},
+                include_body,
+            )
+            return
+
+        # There is exactly one identity (the pod user), so the api-version and
+        # the client_id/object_id/mi_res_id selectors are accepted but ignored.
+        scope = resource.rstrip("/") + "/.default"
+        try:
+            token = zone_token_broker.get_token(scope)
+        except Exception as error:
+            self._send_json(
+                500,
+                {"error": "broker_error", "error_description": zone_token_broker._redact(error)},
+                include_body,
+            )
+            return
+
+        # expires_on must be numeric epoch seconds as a string: both MSAL and
+        # azure-identity call int() on it.
+        self._send_json(
+            200,
+            {
+                "access_token": token.access_token,
+                "expires_on": str(int(token.expires_on)),
+                "token_type": "Bearer",
+                "resource": resource,
+            },
+            include_body,
+        )
+
+    def _send_json(self, status, payload, include_body):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if include_body:
+            self.wfile.write(body)
+
+    # One terse line per request to stderr; never log query strings verbatim
+    # so future protocol changes cannot leak secrets into service logs.
+    def log_message(self, format, *args):  # noqa: A002 - stdlib signature
+        print(f"zone-msi-shim: {format % args}", file=sys.stderr)
+
+    def log_request(self, code="-", size="-"):
+        self.log_message("%s %s %s", self.command, urlparse(self.path).path, code)
+
+
+def main():
+    port = int(os.environ.get(PORT_ENV, DEFAULT_PORT))
+    server = ThreadingHTTPServer((BIND_ADDRESS, port), MsiRequestHandler)
+    print(f"zone-msi-shim: serving managed-identity tokens on http://{BIND_ADDRESS}:{port}", file=sys.stderr)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/mid/test_zone_msi.py
+++ b/tests/mid/test_zone_msi.py
@@ -1,0 +1,206 @@
+"""
+test_zone_msi
+~~~~~~~~~~~~~
+Test the managed-identity endpoint shim (zone-msi-shim).
+
+The mid image emulates the App Service managed-identity protocol so that
+`az login --identity`, DefaultAzureCredential, and ManagedIdentityCredential
+authenticate as the pod user through the Zone token broker. This test
+verifies that:
+
+- zone-msi-shim is installed and IDENTITY_ENDPOINT/IDENTITY_HEADER are set
+- the shim translates an MSI token request into a broker call and returns
+  the App Service response shape (numeric expires_on, Bearer token_type)
+- requests with a wrong X-IDENTITY-HEADER are rejected with 401
+- azure-identity's ManagedIdentityCredential works end-to-end against the
+  shim (skipped when azure-identity is not installed in the image)
+
+The broker itself is mocked with a stdlib HTTP server inside the container,
+so no cluster AuthService is needed.
+
+Example:
+
+    $ make test/mid
+
+    # [...]
+    # test/mid/test_zone_msi.py::test_zone_msi_shim_installed
+    # test/mid/test_zone_msi.py::test_zone_msi_shim_returns_broker_token
+"""
+
+import json
+import logging
+import pytest
+
+from tests.general.wait_utils import wait_for_exec_success
+
+LOGGER = logging.getLogger(__name__)
+
+# Distinct ports so the probe never collides with the s6-managed shim on 8901.
+MOCK_BROKER_PORT = 18902
+PROBE_SHIM_PORT = 18903
+
+# Bash driver: mock broker + private shim instance + curl probes. Written via
+# heredoc (like test_parquet) to avoid shell quoting issues, and printing
+# MARKER: lines that the test parses from the combined output.
+PROBE_SCRIPT = (
+    "set -u\n"
+    "cat > /tmp/zone_msi_mock_broker.py <<'PYEOF'\n"
+    "import json, time\n"
+    "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+    "class Handler(BaseHTTPRequestHandler):\n"
+    "    def do_GET(self):\n"
+    "        body = json.dumps({'access_token': 'testtoken123', 'expires_on': int(time.time()) + 3600}).encode()\n"
+    "        self.send_response(200)\n"
+    "        self.send_header('Content-Type', 'application/json')\n"
+    "        self.send_header('Content-Length', str(len(body)))\n"
+    "        self.end_headers()\n"
+    "        self.wfile.write(body)\n"
+    "    def log_message(self, *args):\n"
+    "        pass\n"
+    f"HTTPServer(('127.0.0.1', {MOCK_BROKER_PORT}), Handler).serve_forever()\n"
+    "PYEOF\n"
+    "python3 /tmp/zone_msi_mock_broker.py &\n"
+    "BROKER_PID=$!\n"
+    f"AUTHSERVICE_BROKER_URL=http://127.0.0.1:{MOCK_BROKER_PORT} "
+    f"ZONE_MSI_PORT={PROBE_SHIM_PORT} IDENTITY_HEADER=zone-test zone-msi-shim &\n"
+    "SHIM_PID=$!\n"
+    "trap 'kill $BROKER_PID $SHIM_PID 2>/dev/null' EXIT\n"
+    f"MSI_URL='http://127.0.0.1:{PROBE_SHIM_PORT}/msi/token"
+    "?api-version=2019-08-01&resource=https://management.azure.com/'\n"
+    "for _ in $(seq 1 30); do\n"
+    "  curl -sf -H 'X-IDENTITY-HEADER: zone-test' \"$MSI_URL\" > /tmp/zone_msi_token.json && break\n"
+    "  sleep 0.5\n"
+    "done\n"
+    "echo \"TOKEN_RESPONSE:$(cat /tmp/zone_msi_token.json)\"\n"
+    "echo \"MISMATCH_STATUS:$(curl -s -o /dev/null -w '%{http_code}' -H 'X-IDENTITY-HEADER: wrong' \"$MSI_URL\")\"\n"
+    "if python3 -c 'import azure.identity' 2>/dev/null; then\n"
+    f"  IDENTITY_ENDPOINT=http://127.0.0.1:{PROBE_SHIM_PORT}/msi/token "
+    "IDENTITY_HEADER=zone-test python3 - <<'PYEOF'\n"
+    "from azure.identity import ManagedIdentityCredential\n"
+    "token = ManagedIdentityCredential().get_token('https://management.azure.com/.default')\n"
+    "assert token.token == 'testtoken123', token.token\n"
+    "print('AZURE_IDENTITY:OK')\n"
+    "PYEOF\n"
+    "else\n"
+    "  echo 'AZURE_IDENTITY:ABSENT'\n"
+    "fi\n"
+)
+
+
+def _marker_value(output, marker):
+    for line in output.splitlines():
+        if line.startswith(marker):
+            return line[len(marker):]
+    return None
+
+
+@pytest.mark.integration
+def test_zone_msi_shim_installed(container):
+    """Test that the shim binary and MSI discovery env vars are in the image.
+
+    azure-identity and MSAL only speak the App Service protocol when both
+    IDENTITY_ENDPOINT and IDENTITY_HEADER are present, so these env vars are
+    as load-bearing as the shim binary itself.
+    """
+    image_name = container.image_name.lower()
+    if 'base' in image_name:
+        pytest.skip("zone-msi-shim not expected in base image")
+
+    LOGGER.info("Testing zone-msi-shim installation...")
+
+    container.run()
+
+    success, output = wait_for_exec_success(
+        container=container,
+        command=["which", "zone-msi-shim"],
+        timeout=30,
+        initial_delay=0.5,
+        max_delay=3.0
+    )
+
+    if not success:
+        raise AssertionError(
+            f"zone-msi-shim not found on PATH within timeout. Output: {output}"
+        )
+
+    result = container.container.exec_run(
+        ["sh", "-c", "printenv IDENTITY_ENDPOINT && printenv IDENTITY_HEADER"]
+    )
+    env_output = result.output.decode('utf-8')
+    assert result.exit_code == 0, f"IDENTITY_ENDPOINT/IDENTITY_HEADER not set: {env_output}"
+
+    lines = env_output.splitlines()
+    assert len(lines) >= 2, f"Unexpected printenv output: {env_output}"
+    identity_endpoint, identity_header = lines[0].strip(), lines[1].strip()
+    LOGGER.info(f"IDENTITY_ENDPOINT={identity_endpoint} IDENTITY_HEADER={identity_header}")
+
+    assert identity_endpoint.startswith("http://127.0.0.1:"), \
+        f"IDENTITY_ENDPOINT should point at loopback: {identity_endpoint}"
+    assert identity_header, "IDENTITY_HEADER should be non-empty"
+
+    LOGGER.info("zone-msi-shim installation test passed successfully")
+
+
+@pytest.mark.integration
+def test_zone_msi_shim_returns_broker_token(container):
+    """Test the shim end-to-end against a mock broker inside the container.
+
+    Starts a stdlib HTTP server standing in for AuthService, points a private
+    shim instance at it, then asserts the App Service response shape via curl
+    and (when azure-identity is installed) via ManagedIdentityCredential.
+    """
+    image_name = container.image_name.lower()
+    if 'base' in image_name:
+        pytest.skip("zone-msi-shim not expected in base image")
+
+    LOGGER.info("Testing zone-msi-shim token exchange against a mock broker...")
+
+    container.run()
+
+    success, output = wait_for_exec_success(
+        container=container,
+        command=["which", "zone-msi-shim"],
+        timeout=30,
+        initial_delay=0.5,
+        max_delay=3.0
+    )
+
+    if not success:
+        raise AssertionError(
+            f"Container failed to be ready for execution within timeout. Output: {output}"
+        )
+
+    # Execute via heredoc to prevent shell quoting issues
+    command = [
+        "bash", "-c",
+        f"cat << 'EOF' > /tmp/zone_msi_probe.sh\n{PROBE_SCRIPT}\nEOF\nbash /tmp/zone_msi_probe.sh"
+    ]
+
+    result = container.container.exec_run(command)
+    probe_output = result.output.decode('utf-8')
+
+    if result.exit_code != 0:
+        LOGGER.error(f"zone-msi probe failed: {probe_output}")
+        assert False, f"zone-msi probe failed with exit code {result.exit_code}: {probe_output}"
+
+    token_response = _marker_value(probe_output, "TOKEN_RESPONSE:")
+    assert token_response, f"No token response from shim: {probe_output}"
+    payload = json.loads(token_response)
+    assert payload.get("access_token") == "testtoken123", f"Unexpected token payload: {payload}"
+    assert payload.get("token_type") == "Bearer", f"Unexpected token payload: {payload}"
+    # MSAL and azure-identity call int() on expires_on, so it must be numeric.
+    assert str(int(payload["expires_on"])) == payload["expires_on"], \
+        f"expires_on must be numeric epoch seconds: {payload}"
+
+    mismatch_status = _marker_value(probe_output, "MISMATCH_STATUS:")
+    assert mismatch_status == "401", \
+        f"Wrong X-IDENTITY-HEADER should be rejected with 401, got {mismatch_status}: {probe_output}"
+
+    azure_identity = _marker_value(probe_output, "AZURE_IDENTITY:")
+    if azure_identity == "ABSENT":
+        LOGGER.info("azure-identity not installed in image; skipping ManagedIdentityCredential sub-check")
+    else:
+        assert azure_identity == "OK", \
+            f"ManagedIdentityCredential sub-check failed: {probe_output}"
+
+    LOGGER.info("zone-msi-shim token exchange test passed successfully")


### PR DESCRIPTION
## Problem

Device-code auth is being retired. The in-pod browser approach (#281) is blocked by pod egress: Entra sign-in pages need GC SSO (sso1.gcsso.gc.ca) and Microsoft CDN hosts that notebook pods cannot reliably reach — navigations die before commit and the Zone Browser tab strands on about:blank.

## Solution

Reuse the sign-in the user already performed: their zone.statcan.ca login. AuthService's `getPassthroughToken` performs an on-behalf-of exchange and returns delegated tokens **as the pod user** (the mechanism already in production for Storage via zone-dvc). New `zone-msi-shim` exposes that broker over the **App Service managed-identity protocol** on loopback — which MSAL and azure-identity auto-detect via `IDENTITY_ENDPOINT`/`IDENTITY_HEADER`.

Result, with zero client configuration:
- `az login --identity` — no browser, no device code, no new egress
- Python `DefaultAzureCredential()` / `ManagedIdentityCredential()`
- R via the existing native broker client (AzureAuth pins the IMDS IP, so R bypasses the shim)

Per-user by construction: pod IP → namespace → that user's session → OBO token. Concurrent users are isolated by namespace, same trust model as the existing broker.

## Changes

- `images/mid/zone-token-broker/zone_msi_shim.py` — stdlib-only loopback server (127.0.0.1:8901); `resource` → `scope/.default` → broker (cached); X-IDENTITY-HEADER check; numeric-epoch `expires_on`; broker failures return `broker_error` so credential chains fall through
- s6 service `zone-msi` starts the shim at pod boot; `IDENTITY_ENDPOINT`/`IDENTITY_HEADER` set in the mid image
- `tests/mid/test_zone_msi.py` — in-image test against a mock broker
- `images/mid/azure-sign-in.md` (seeded to $HOME) — user guide; `docs/zone-msi-login.md` — architecture/security reference

## Prerequisite (platform)

Admin consent for the **already-configured** delegated permission *Azure Service Management → user_impersonation* on the **DAaaS: Kubeflow** app registration (one click — same as the granted Azure SQL permission below it). Until then ARM scopes return AADSTS65001.

## Validation

Container harness: protocol responses verified (200 token shape / 401 header mismatch / 400 missing resource); real `az login --identity` auto-detected the shim, fetched and parsed the brokered token, and proceeded to ARM. The final leg (genuine OBO token) requires the in-cluster AuthService + consent — that is the cluster acceptance test.

## Relationship to #281

Replaces the in-pod browser approach; #281 stays open only until this is validated on cluster, then closes unmerged.